### PR TITLE
add subapplication path to default service name

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -151,8 +151,10 @@ namespace Datadog.Trace
 #if !NETSTANDARD2_0
                 if (System.Web.Hosting.HostingEnvironment.IsHosted)
                 {
-                    // if we are hosted as an ASP.NET application, return the site name
-                    return System.Web.Hosting.HostingEnvironment.SiteName;
+                    // if we are hosted as an ASP.NET application, return SiteName/Path.
+                    // note that ApplicationVirtualPath includes a leading slash,
+                    // and is just a slash if this application is not a subapplication.
+                    return System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath;
                 }
 #endif
                 return Assembly.GetEntryAssembly()?.GetName().Name ??


### PR DESCRIPTION
This PR adds the subapplication path (if any) to the default service name, so that the result is now `SiteName/VirtualPath` (instead of just the `SiteName` for all subapplications).