### PR TITLE
[MVC5] include request Host header as a span tag

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -63,7 +63,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     return;
                 }
 
+                string host = _httpContext.Request.Headers.Get("Host");
                 string httpMethod = _httpContext.Request.HttpMethod.ToUpperInvariant();
+                string url = _httpContext.Request.RawUrl.ToLowerInvariant();
 
                 IDictionary<string, object> routeValues = controllerContext.RouteData.Values;
                 string controllerName = routeValues.GetValueOrDefault("controller") as string;
@@ -74,8 +76,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 Span span = _scope.Span;
                 span.Type = SpanTypes.Web;
                 span.ResourceName = resourceName;
+                span.SetTag(Tags.HttpRequestHeadersHost, host);
                 span.SetTag(Tags.HttpMethod, httpMethod);
-                span.SetTag(Tags.HttpUrl, _httpContext.Request.RawUrl.ToLowerInvariant());
+                span.SetTag(Tags.HttpUrl, url);
                 span.SetTag(Tags.AspNetRoute, (string)controllerContext.RouteData.Route.Url);
                 span.SetTag(Tags.AspNetController, controllerName);
                 span.SetTag(Tags.AspNetAction, actionName);

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -16,6 +16,11 @@ namespace Datadog.Trace
         public const string HttpMethod = "http.method";
 
         /// <summary>
+        /// The host of an HTTP request
+        /// </summary>
+        public const string HttpRequestHeadersHost = "http.request.headers.host";
+
+        /// <summary>
         /// The status code of an HTTP response
         /// </summary>
         public const string HttpStatusCode = "http.status_code";


### PR DESCRIPTION
This PR adds the web request's `Host` header as a span tag in the ASP.NET MVC 5 integration.