### PR TITLE
valid default service names for unit tests

### DIFF
--- a/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.TestHelpers;
 using Moq;
 using OpenTracing;
 using OpenTracing.Propagation;
@@ -26,7 +27,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             var builder = _tracer.BuildSpan("Op1");
             var span = (OpenTracingSpan)builder.Start();
 
-            Assert.Equal("testhost", span.DDSpan.ServiceName);
+            Assert.Contains(span.DDSpan.ServiceName, TestRunners.ValidNames);
             Assert.Equal("Op1", span.DDSpan.OperationName);
         }
 

--- a/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class TestRunners
+    {
+        public static readonly IEnumerable<string> ValidNames = new[]
+                                                                {
+                                                                    "testhost",
+                                                                    "vstest.console",
+                                                                    "xunit.console.x86",
+                                                                    "xunit.console.x64"
+                                                                };
+    }
+}

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.TestHelpers;
 using Moq;
 using Xunit;
 
@@ -128,7 +129,7 @@ namespace Datadog.Trace.Tests
         {
             var scope = _tracer.StartActive("Operation");
 
-            Assert.Equal("testhost", scope.Span.ServiceName);
+            Assert.Contains(scope.Span.ServiceName, TestRunners.ValidNames);
         }
 
         [Fact]


### PR DESCRIPTION
This PR replaces `testhost` with a _list_ of valid default service names that can come up when running unit tests. A list is required because the default service name for non-web applications is the process name, but unit tests can be run with different "runners" (e.g. VS, Resharper, xunit CLI, vstest CLI).