### PR TITLE
Fix dev environment variables

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -7,16 +7,16 @@ rem enabling the profiler for apps run from VS, including while debugging.
 rem Enable .NET Framework Profiling API
 SET COR_ENABLE_PROFILING=1
 SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-SET COR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x64\Debug\Datadog.Trace.ClrProfiler.Native.dll
-SET COR_PROFILER_PATH_64=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x64\Debug\Datadog.Trace.ClrProfiler.Native.dll
-SET COR_PROFILER_PATH_32=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x86\Debug\Datadog.Trace.ClrProfiler.Native.dll
+SET COR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x64\Datadog.Trace.ClrProfiler.Native.dll
+SET COR_PROFILER_PATH_64=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x64\Datadog.Trace.ClrProfiler.Native.dll
+SET COR_PROFILER_PATH_32=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x86\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Enable .NET Core Profiling API
 SET CORECLR_ENABLE_PROFILING=1
 SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x64\Debug\Datadog.Trace.ClrProfiler.Native.dll
-SET CORECLR_PROFILER_PATH_64=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x64\Debug\Datadog.Trace.ClrProfiler.Native.dll
-SET CORECLR_PROFILER_PATH_32=%~dp0\src\Datadog.Trace.ClrProfiler.Native\x86\Debug\Datadog.Trace.ClrProfiler.Native.dll
+SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x64\Datadog.Trace.ClrProfiler.Native.dll
+SET CORECLR_PROFILER_PATH_64=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x64\Datadog.Trace.ClrProfiler.Native.dll
+SET CORECLR_PROFILER_PATH_32=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debug\x86\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Limit profiling to these processes only
 SET DATADOG_PROFILER_PROCESSES=ConsoleApp.exe;w3wp.exe;iisexpress.exe;Samples.AspNetCoreMvc2.exe;dotnet.exe;Samples.ConsoleFramework.exe


### PR DESCRIPTION
This PR makes the environment variable `DATADOG_PROFILER_PROCESSES` optional. If not set, the profiler will attach to all .NET processes that have Profiling API enabled (e.g. `COR_ENABLE_PROFILING`). This makes testing easier (I keep forgetting to set the variable), and the env. variable is still set by the Windows installer so only web applications running in IIS are profiled by default.

The batch script that sets environment variables for development also required some fixed since I changed the paths to the native dll recently.