### PR TITLE
Fix Windows installer (msi)

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Include>
-  <?define BaseProductName = "APM Tracing for .NET" ?>
+  <?define BaseProductName = ".NET Tracing" ?>
+  <?define ArpManufacturer = "Datadog, Inc." ?>
+  <?define Company = "Datadog" ?>
+  <?define ManagedDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45" ?>
+  <?define NativeDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\$(var.Platform)" ?>
+  <?define ProfilerCLSID = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" ?>
 
   <?if $(var.Platform) = x64 ?>
   <?define ProductName = "Datadog $(var.BaseProductName) 64-bit" ?>
@@ -12,7 +17,4 @@
   <?define Win64 = "no" ?>
   <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
   <?endif ?>
-
-  <?define NativeDllName = "Datadog.Trace.ClrProfiler.Native.dll" ?>
-  <?define ProfilerCLSID = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" ?>
 </Include>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <!-- This ProductVersion property refers to the version of the WiX Toolset,
          not the installer this project generates.
          DO NOT CHANGE this one. Change <Version> below. -->
@@ -10,14 +10,15 @@
     <ProjectGuid>3054de0e-f140-4758-b2da-0b9470c6ede1</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Package</OutputType>
-    <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
-    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <OutputPath>bin\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
     <!-- Custom Version property for the generated installer,
          value is set to constant ProductVersion below and
          accessed as $(var.ProductVersion) from WiX files.
-         CHANGE THIS ONE when bumping the library version. -->
-    <Version>0.2.0</Version>
+         This is the default value is one is not specified when building. -->
+    <Version Condition="'$(Version)'==''">0.2.3</Version>
     <OutputName>DatadogDotNetTracing-$(Version)-$(Platform)-$(Configuration)</OutputName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -58,10 +59,6 @@
   <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
-  <PropertyGroup>
-    <PostBuildEvent>mkdir $(ProjectDir)\output
-copy !(TargetPath) $(ProjectDir)\output</PostBuildEvent>
-  </PropertyGroup>
   <!--
 	To modify your build process, add your task inside one of the targets below and uncomment it.
 	Other similar extension points exist, see Wix.targets.

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -106,7 +106,9 @@
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
         <Environment Id="DATADOG_APM_DOTNET_HOME" Name="DATADOG_APM_DOTNET_HOME" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]" Part="all"/>
+        <!--
         <Environment Id="DATADOG_INTEGRATIONS" Name="DATADOG_INTEGRATIONS" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]\integrations.json" Part="all" />
+        -->
       </Component>
     </ComponentGroup>
 

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -39,6 +39,10 @@
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.User"/>
     </Feature>
+
+    <InstallExecuteSequence>
+      <ScheduleReboot After='InstallFinalize'/>
+    </InstallExecuteSequence>
   </Product>
 
   <Fragment>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -6,33 +6,21 @@
            Name="$(var.ProductName)"
            Language="1033"
            Version="$(var.ProductVersion)"
-           Manufacturer="Datadog, Inc."
+           Manufacturer="$(var.ArpManufacturer)"
            UpgradeCode="fc228e86-eae2-4c2a-ae82-135b718c269e">
     <Package InstallerVersion="200"
              Compressed="yes"
              InstallScope="perMachine"
              Description="$(var.ProductName)" />
 
-    <!--
-        <Property Id="ARPCOMMENTS">any comments</Property>
-        <Property Id="ARPCONTACT">contact info</Property>
-        <Property Id="ARPURLUPDATEINFO">URL for product updates</Property>
-        <Property Id="ARPHELPTELEPHONE">URL for technical support</Property>
-        <Property Id="ARPREADME">path</Property>
-        <Property Id="ARPNOREMOVE">1</Property>
-        <Property Id="ARPNOREPAIR">1</Property>
-        <Property Id="ARPNOMODIFY">1</Property>
-        <Property Id="ARPSIZE">32</Property>
-        -->
     <Icon Id="datadog.ico" SourceFile="datadog-icon.ico"/>
-
     <Property Id="ARPPRODUCTICON">datadog.ico</Property>
     <Property Id="ARPURLINFOABOUT">https://datadoghq.com/</Property>
     <Property Id="ARPHELPLINK">https://datadoghq.com/support/</Property>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
 
     <Property Id="INSTALLFOLDER">
-      <RegistrySearch Id="RegistrySearch" Type="raw" Root="HKLM" Win64="$(var.Win64)" Key="Software\Company\Product" Name="InstallLocation"/>
+      <RegistrySearch Id="RegistrySearch" Type="raw" Root="HKLM" Win64="$(var.Win64)" Key="Software\$(var.Company)\$(var.ProductName)" Name="InstallPath"/>
     </Property>
 
     <UIRef Id="WixUI_InstallDir_Custom"/>
@@ -47,7 +35,7 @@
       <ComponentGroupRef Id="Files"/>
       <ComponentGroupRef Id="Files.Native"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
-      <!-- <ComponentGroupRef Id="Files.Managed.NetCoreApp20"/> -->
+      <ComponentGroupRef Id="Registry"/>
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.User"/>
     </Feature>
@@ -56,7 +44,7 @@
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.PlatformProgramFilesFolder)">
-        <Directory Id="ProgramFilesFolder.Datadog" Name="Datadog">
+        <Directory Id="ProgramFilesFolder.Datadog" Name="$(var.Company)">
           <Directory Id="INSTALLFOLDER" Name="$(var.BaseProductName)">
             <Directory Id="INSTALLFOLDER_NET45" Name="net45"/>
             <Directory Id="INSTALLFOLDER_NETCOREAPP20" Name="netcoreapp2.0"/>
@@ -75,53 +63,42 @@
     <ComponentGroup Id="Files.Managed.Net45" Directory="INSTALLFOLDER_NET45">
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.ManagedDllPath)\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45\Datadog.Trace.dll"
+              Source="$(var.ManagedDllPath)\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_MsgPack.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45\MsgPack.dll"
+              Source="$(var.ManagedDllPath)\MsgPack.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.ManagedDllPath)\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
     </ComponentGroup>
 
-    <!--
-    <ComponentGroup Id="Files.Managed.NetCoreApp20" Directory="INSTALLFOLDER_NETCOREAPP20">
-      <Component Win64="$(var.Win64)">
-        <File Id="netcoreapp2.0_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\netcoreapp2.0\Datadog.Trace.ClrProfiler.Managed.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="netcoreapp2.0_Datadog.Trace.dll"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\netcoreapp2.0\Datadog.Trace.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="netcoreapp2.0_Datadog.Trace.ClrProfiler.Managed.deps.json"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\netcoreapp2.0\Datadog.Trace.ClrProfiler.Managed.deps.json"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-    </ComponentGroup>
-    -->
-
     <ComponentGroup Id="Files.Native" Directory="INSTALLFOLDER">
       <Component Win64="$(var.Win64)">
         <File Id="Datadog.Trace.ClrProfiler.Native"
-              Source="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\$(var.Platform)\$(var.NativeDllName)"
+              Source="$(var.NativeDllPath)\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductName)"/>
         </File>
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="Registry" Directory="INSTALLFOLDER">
+      <Component Win64="$(var.Win64)">
+        <CreateFolder/>
+        <RegistryKey Root="HKLM" Key="Software\$(var.Company)\$(var.ProductName)">
+          <RegistryValue Type="string" Name="InstallPath" Value="[INSTALLFOLDER]" Action="write"/>
+        </RegistryKey>
       </Component>
     </ComponentGroup>
 
@@ -130,30 +107,7 @@
         <CreateFolder/>
         <Environment Id="DATADOG_APM_DOTNET_HOME" Name="DATADOG_APM_DOTNET_HOME" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]" Part="all"/>
         <Environment Id="DATADOG_INTEGRATIONS" Name="DATADOG_INTEGRATIONS" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]\integrations.json" Part="all" />
-        <!--
-        <Environment Id="COR_ENABLE_PROFILING" Name="COR_ENABLE_PROFILING" Action="create" Permanent="no" System="yes" Value="0"/>
-        <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="create" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)"/>
-
-        <Environment Id="CORECLR_ENABLE_PROFILING" Name="CORECLR_ENABLE_PROFILING" Action="create" Permanent="no" System="yes" Value="0"/>
-        <Environment Id="CORECLR_PROFILER" Name="CORECLR_PROFILER" Action="create" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)"/>
-        -->
       </Component>
-
-      <!--
-      <?if $(var.Platform) = x64 ?>
-      <Component Id="EnvironmentVariables64" Guid="{D52A5BBD-FCA1-46D6-BFD5-AF5A883D5878}" Win64="$(var.Win64)">
-        <CreateFolder/>
-        <Environment Id="COR_PROFILER_PATH_64" Name="COR_PROFILER_PATH_64" Action="create" Permanent="no" System="yes" Value="[INSTALLFOLDER]$(var.NativeDllName)"/>
-        <Environment Id="CORECLR_PROFILER_PATH_64" Name="CORECLR_PROFILER_PATH_64" Action="create" Permanent="no" System="yes" Value="[INSTALLFOLDER]$(var.NativeDllName)"/>
-      </Component>
-      <?else ?>
-      <Component Id="EnvironmentVariables32" Guid="{5206971B-1BCA-412A-BD1C-33EE76799399}" Win64="$(var.Win64)">
-        <CreateFolder/>
-        <Environment Id="COR_PROFILER_PATH_32" Name="COR_PROFILER_PATH_32" Action="create" Permanent="no" System="yes" Value="[INSTALLFOLDER]$(var.NativeDllName)"/>
-        <Environment Id="CORECLR_PROFILER_PATH_32" Name="CORECLR_PROFILER_PATH_32" Action="create" Permanent="no" System="yes" Value="[INSTALLFOLDER]$(var.NativeDllName)"/>
-      </Component>
-      <?endif ?>
-      -->
     </ComponentGroup>
 
     <ComponentGroup Id="EnvironmentVariables.User" Directory="INSTALLFOLDER">


### PR DESCRIPTION
This PR fixes several issues with the WiX project which builds the Windows installer (msi):

- skip setting the `DATADOG_INTEGRATIONS` for now because the json definitions are broken
- schedule a system reboot after installation so IIS can pick up new environment variables
- allow `Version` property to be set by CI, keep fallback for development environments
- the company name to match the Agent installer (which uses `Datadog` in some places and `Datadog, Inc.` in others)
- save install path to registry so future updates/uninstalls can find it more reliably (since users can change the path during installation)
- target `Release`/`x64` by default when building
- refactors variables for better DRY
- remove lots of commented code