### PR TITLE
don't require use of GAC in sample projects

### DIFF
--- a/samples/Samples.AspNetCoreMvc2/Samples.AspNetCoreMvc2.csproj
+++ b/samples/Samples.AspNetCoreMvc2/Samples.AspNetCoreMvc2.csproj
@@ -19,4 +19,8 @@
       <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.4" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -99,6 +99,12 @@
   <ItemGroup>
     <Folder Include="Models\" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
+      <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
+      <Name>Datadog.Trace.ClrProfiler.Managed</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>


### PR DESCRIPTION
This PR adds references to `Datadog.Trace.ClrProfiler.Managed` in the sample projects to make testing by deploying the required dll with the sample apps instead of requiring use of the GAC.