### PR TITLE
optional DATADOG_PROFILER_PROCESSES

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -20,6 +20,8 @@ SET CORECLR_PROFILER_PATH_32=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\Debu
 
 rem Limit profiling to these processes only
 SET DATADOG_PROFILER_PROCESSES=ConsoleApp.exe;w3wp.exe;iisexpress.exe;Samples.AspNetCoreMvc2.exe;dotnet.exe;Samples.ConsoleFramework.exe;Samples.ConsoleCore.exe
+
+rem Set location of integration definitions
 SET DATADOG_INTEGRATIONS=%~dp0\integrations.json;%~dp0\test-integrations.json
 
 rem Open solution in Visual Studio


### PR DESCRIPTION
This PR fixes a crash when environment variable `DATADOG_PROFILER_PROCESSES` is not set. The profiler code used to bail out and not instrument anything when this variable was not set. I broke this recently in #78 when I tried to make this variable optional to allow the profiler to attach to _any_ process.

I recommend hiding whitespace changes since many lines changed only indentation.