### PR TITLE
DATADOG_PROFILER_PROCESSES redux

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -15,7 +15,7 @@ void split(const std::wstring &s, wchar_t delim, Out result) {
   }
 }
 
-std::vector<std::wstring> split(const std::wstring &s, wchar_t delim) {
+inline std::vector<std::wstring> split(const std::wstring &s, wchar_t delim) {
   std::vector<std::wstring> elems;
   split(s, delim, std::back_inserter(elems));
   return elems;


### PR DESCRIPTION
Clean up the C++ code around getting environment variable `DATADOG_PROFILER_PROCESSES` and make it optional (for real this time).
