### PR TITLE
add missing configuration/platform combinations

### DIFF
--- a/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
+++ b/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
@@ -14,23 +14,42 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>x64</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>
+    </DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <PlatformTarget>x86</PlatformTarget>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
+++ b/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
@@ -38,18 +38,22 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <Optimize>true</Optimize>
+    <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
     <Optimize>true</Optimize>
+    <OutputPath>bin\x64\Release\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <PlatformTarget>x86</PlatformTarget>
+    <OutputPath>bin\x86\Debug\</OutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <PlatformTarget>x64</PlatformTarget>
+    <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
@@ -20,9 +21,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [Fact]
+        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1025:CodeMustNotContainMultipleWhitespaceInARow", Justification = "Reviewed.")]
         public void ProfilerAttached()
         {
             var platform = Environment.Is64BitProcess ? "x64" : "x86";
+
+            var os = Environment.OSVersion.Platform == PlatformID.Win32NT ? "win" :
+                     Environment.OSVersion.Platform == PlatformID.Unix    ? "linux" :
+                     Environment.OSVersion.Platform == PlatformID.MacOSX  ? "osx" :
+                                                                            string.Empty;
+
+            var runtimeIdentifier = BuildParameters.CoreClr ? string.Empty : $"{os}-{platform}";
+
             string basePath = Path.GetFullPath(@"..\..\..\..\..\..");
 
             // get path to native profiler dll
@@ -30,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Assert.True(File.Exists(profilerDllPath), $"Profiler DLL not found at {profilerDllPath}");
 
             // get path to sample app that the profiler will attach to
-            string appBasePath = $@"{basePath}\samples\Samples.ConsoleCore\bin\{platform}\{BuildParameters.Configuration}\{BuildParameters.TargetFramework}";
+            string appBasePath = $@"{basePath}\samples\Samples.ConsoleCore\bin\{platform}\{BuildParameters.Configuration}\{BuildParameters.TargetFramework}\{runtimeIdentifier}";
             string appFileName = BuildParameters.CoreClr ? $@"{appBasePath}\Samples.ConsoleCore.dll" : $@"{appBasePath}\Samples.ConsoleCore.exe";
             string appPath = Path.Combine(appBasePath, appFileName);
             Assert.True(File.Exists(appPath), $"Application not found at {appPath}");


### PR DESCRIPTION
This PR adds missing configuration/platform combinations to `Samples.ConsoleFramework` project so it can be built as x86 and x64 in CI.