### PR TITLE
add more logging in ModuleLoadFinished() and JITCompilationStarted()

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -78,15 +78,17 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     return S_OK;
   }
 
-  LOG_APPEND(L"ModuleLoadFinished for " + module_info.assembly.name +
-             L". Emitting instrumentation metadata.");
-
   std::vector<Integration> enabled_integrations =
       FilterIntegrationsByCaller(integrations_, module_info.assembly.name);
   if (enabled_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
+    LOG_APPEND(L"ModuleLoadFinished() called for "
+               << assemblyName << ". Skipping instrumentation.");
     return S_OK;
   }
+
+  LOG_APPEND(L"ModuleLoadFinished() called for "
+             << assemblyName << ". Emitting instrumentation metadata.");
 
   ComPtr<IUnknown> metadata_interfaces;
 
@@ -234,6 +236,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   }
 
   if (modified) {
+          LOG_APPEND(L"JITCompilationStarted() called for "
+                     << caller_type_name << "." << caller_method_name
+                     << "(). Replacing calls to "
+                     << method_replacement.target_method.type_name << "."
+                     << method_replacement.target_method.method_name
+                     << "() with calls to "
+                     << method_replacement.wrapper_method.type_name << "."
+                     << method_replacement.wrapper_method.method_name << "().");
+
     hr = rewriter.Export();
     RETURN_OK_IF_FAILED(hr);
   }


### PR DESCRIPTION
Note that this PR targets `caleb/profiler-2` instead of `master` to avoid merge conflict.
- fix logging in `ModuleLoadFinished()` so it shows whether a module is being instrumented or not
- added logging in `JITCompilationStarted()` to shows called, target, and wrapper when a method is replaced
