### PR TITLE
remove trailing slash from default service name

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -151,10 +151,9 @@ namespace Datadog.Trace
 #if !NETSTANDARD2_0
                 if (System.Web.Hosting.HostingEnvironment.IsHosted)
                 {
-                    // if we are hosted as an ASP.NET application, return SiteName/Path.
-                    // note that ApplicationVirtualPath includes a leading slash,
-                    // and is just a slash if this application is not a subapplication.
-                    return System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath;
+                    // if we are hosted as an ASP.NET application, return "SiteName/ApplicationVirtualPath".
+                    // note that ApplicationVirtualPath includes a leading slash.
+                    return (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
                 }
 #endif
                 return Assembly.GetEntryAssembly()?.GetName().Name ??


### PR DESCRIPTION
When a web application is hosted in IIS as a "web site" and not an "application" inside a web site (aka subapplication), the path is just a slash. If so, remove the trailing slash.