### PR TITLE
Reduce C++ compiler optimizations, redux

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -117,10 +117,9 @@
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <OmitFramePointers>
-      </OmitFramePointers>
+      <OmitFramePointers>false</OmitFramePointers>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
@@ -135,11 +134,12 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PreprocessorDefinitions>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard>stdcpp17</LanguageStandard>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <ConformanceMode>true</ConformanceMode>
+      <OmitFramePointers>false</OmitFramePointers>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -251,21 +251,20 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       if (method_replacement.target_method.type_name == target.type.name &&
           method_replacement.target_method.method_name == target.name) {
         // replace with a call to the instrumentation wrapper
+        INT32 original_argument = pInstr->m_Arg32;
         pInstr->m_opcode = CEE_CALL;
         pInstr->m_Arg32 = wrapper_method_ref;
 
         modified = true;
-      }
-    }
 
-    if (modified) {
-      LOG_APPEND(L"JITCompilationStarted() replaced calls from "
-                 << caller.type.name << "." << caller.name << "() to "
-                 << method_replacement.target_method.type_name << "."
-                 << method_replacement.target_method.method_name
-                 << "() with calls to "
-                 << method_replacement.wrapper_method.type_name << "."
-                 << method_replacement.wrapper_method.method_name << "().");
+        LOG_APPEND(L"JITCompilationStarted() replaced calls from "
+                   << caller.type.name << "." << caller.name << "() to "
+                   << method_replacement.target_method.type_name << "."
+                   << method_replacement.target_method.method_name
+                   << "() " << HEX(original_argument) << " with calls to "
+                   << method_replacement.wrapper_method.type_name << "."
+                   << method_replacement.wrapper_method.method_name << "() " << HEX(wrapper_method_ref) << ".");
+      }
     }
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -62,7 +62,7 @@ std::wstring GetLocaleFromAssemblyReferenceString(const std::wstring& str) {
 }
 
 PublicKey GetPublicKeyFromAssemblyReferenceString(const std::wstring& str) {
-  uint8_t data[8] = {0};
+  BYTE data[8] = {0};
 
   static auto re = std::wregex(L"PublicKeyToken=([a-fA-F0-9]{16})");
   std::wsmatch match;
@@ -71,7 +71,7 @@ PublicKey GetPublicKeyFromAssemblyReferenceString(const std::wstring& str) {
       auto s = match.str(1).substr(i * 2, 2);
       unsigned long x;
       std::wstringstream(s) >> std::hex >> x;
-      data[i] = uint8_t(x);
+      data[i] = BYTE(x);
     }
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -13,10 +13,10 @@ const size_t kPublicKeySize = 8;
 // PublicKey represents an Assembly Public Key token, which is an 8 byte binary
 // RSA key.
 struct PublicKey {
-  const uint8_t data[kPublicKeySize];
+  const BYTE data[kPublicKeySize];
 
   PublicKey() : data{0} {}
-  PublicKey(const uint8_t (&arr)[kPublicKeySize])
+  PublicKey(const BYTE (&arr)[kPublicKeySize])
       : data{arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7]} {}
 
   inline bool operator==(const PublicKey& other) const {
@@ -92,10 +92,10 @@ struct AssemblyReference {
 // [calling convention, number of parameters, return type, parameter type...]
 struct MethodSignature {
  public:
-  const std::vector<uint8_t> data;
+  const std::vector<BYTE> data;
 
   MethodSignature() {}
-  MethodSignature(const std::vector<uint8_t>& data) : data(data) {}
+  MethodSignature(const std::vector<BYTE>& data) : data(data) {}
 
   inline bool operator==(const MethodSignature& other) const {
     return data == other.data;
@@ -112,7 +112,7 @@ struct MethodReference {
 
   MethodReference(const std::wstring& assembly_name, std::wstring type_name,
                   std::wstring method_name,
-                  const std::vector<uint8_t>& method_signature)
+                  const std::vector<BYTE>& method_signature)
       : assembly(assembly_name),
         type_name(std::move(type_name)),
         method_name(std::move(method_name)),

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -111,11 +111,11 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
   std::wstring type = converter.from_bytes(src.value("type", ""));
   std::wstring method = converter.from_bytes(src.value("method", ""));
   auto arr = src.value("signature", json::array());
-  std::vector<uint8_t> signature;
+  std::vector<BYTE> signature;
   if (arr.is_array()) {
     for (auto& el : arr) {
       if (el.is_number_unsigned()) {
-        signature.push_back(uint8_t(el.get<uint64_t>()));
+        signature.push_back(BYTE(el.get<BYTE>()));
       }
     }
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -52,6 +52,7 @@ HRESULT MetadataBuilder::FindWrapperTypeRef(
   }
 
   HRESULT hr;
+  type_ref = mdTypeRefNil;
 
   const LPCWSTR wrapper_type_name =
       method_replacement.wrapper_method.type_name.c_str();
@@ -68,9 +69,6 @@ HRESULT MetadataBuilder::FindWrapperTypeRef(
         assembly_import_, method_replacement.wrapper_method.assembly.name);
     if (assembly_ref == mdAssemblyRefNil) {
       // TODO: emit assembly reference if not found?
-      LOG_APPEND(L"missing reference to assembly: "
-                 << method_replacement.wrapper_method.assembly.name);
-      type_ref_out = type_ref;
       return S_FALSE;
     }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
@@ -55,6 +55,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             string standardError;
             int exitCode;
 
+            _output.WriteLine($"Platform: {platform}");
+            _output.WriteLine($"Configuration: {BuildParameters.Configuration}");
+            _output.WriteLine($"TargetFramework: {BuildParameters.TargetFramework}");
+            _output.WriteLine($".NET Core: {BuildParameters.CoreClr}");
+            _output.WriteLine($"Application: {appPath}");
+            _output.WriteLine($"Profiler DLL: {profilerDllPath}");
+
             using (Process process = ProfilerHelper.StartProcessWithProfiler(
                 appPath,
                 BuildParameters.CoreClr,
@@ -68,10 +75,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 exitCode = process.ExitCode;
             }
 
-            if (!string.IsNullOrWhiteSpace(standardError))
-            {
-                _output.WriteLine(standardError);
-            }
+            _output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            _output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
 
             Assert.True(exitCode >= 0, $"Process exited with code {exitCode}");
 


### PR DESCRIPTION
See #100. Out of curiosity, someday we should try removing C++17 language features and turning optimizations back on, see if that works. C++17 is still a work in progress in VS, with new features and fixes coming in with updates every few weeks.

Tests ran successfully:
https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/results?buildId=239&view=logs