### PR TITLE
Add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This repository contains what you need to trace .NET applications. Some quick no
 
 ## Build Status
 
-OS|Status
---------|------
-Windows|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
-Linux|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
+OS|Features|Status
+--|--|--
+Windows|manual instrumentation (NuGet), automatic instrumentation (MSI)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
+Linux|manual instrumentation (NuGet)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
 
 ## The Components
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ This repository contains what you need to trace .NET applications. Some quick no
 
 ## Build Status
 
-Platform|Status
+OS|Status
 --------|------
-Windows (manual and automatic instrumentation)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
-Linux (manual instrumentation only for now)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
+Windows|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
+Linux|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
 
 ## The Components
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ This repository contains what you need to trace .NET applications. Some quick no
 - Supports .NET Core 2.0 or newer
 - Multiple AppDomains are not supported
 
+## Build Status
+
+Platform|Status
+--------|------
+Windows (manual and automatic instrumentation)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
+Linux (manual instrumentation only for now)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
+
 ## The Components
 
 
@@ -35,7 +42,7 @@ In order to build and run all the projects and tests included in this repo you n
 
 Some tests require you to have [Docker for Windows](https://docs.docker.com/docker-for-windows/) on your machine or to manually install the required dependencies.
 
-#### Unix
+#### Linux
 
 Make sure you have installed:
 - [.NET Core SDK](https://www.microsoft.com/net/download) (2.0 or newer)


### PR DESCRIPTION
This PR adds build status badges to the repo's README file. Live preview:

Platform|Features|Status
--|--|--
Windows|manual instrumentation (NuGet), automatic instrumentation (MSI)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
Linux|manual instrumentation (NuGet)|[![Build status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
