### PR TITLE
[wip] SQLServer integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -11,7 +11,7 @@
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
           "method": "BeforeAction",
-          "signature":  [0, 4, 28, 28, 28, 28, 28]
+          "signature": [ 0, 4, 28, 28, 28, 28, 28 ]
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -75,6 +75,26 @@
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvc5Integration",
           "method": "EndInvokeAction",
           "signature": [ 0, 2, 2, 28, 28 ]
+        }
+      }
+    ]
+  },
+  {
+    "name": "SqlServer",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteReader",
+          "signature": [ 32, 2, 12, 82, 8, 11, 82, 91, 14 ]
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.SqlServer",
+          "method": "ExecuteReader",
+          "signature": [ 0, 3, 28, 28, 8, 14 ]
         }
       }
     ]

--- a/samples/Samples.ConsoleFramework/App.config
+++ b/samples/Samples.ConsoleFramework/App.config
@@ -1,6 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.SqlConnectionFactory, EntityFramework" />
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/samples/Samples.ConsoleFramework/Models.cs
+++ b/samples/Samples.ConsoleFramework/Models.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Text;
+
+namespace Samples.ConsoleFramework
+{
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string Name { get; set; }
+
+        public virtual List<Post> Posts { get; set; }
+    }
+
+    public class Post
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+
+        public int BlogId { get; set; }
+        public virtual Blog Blog { get; set; }
+    }
+
+    public class BloggingContext : DbContext
+    {
+        public DbSet<Blog> Blogs { get; set; }
+        public DbSet<Post> Posts { get; set; }
+    }
+}

--- a/samples/Samples.ConsoleFramework/Program.cs
+++ b/samples/Samples.ConsoleFramework/Program.cs
@@ -59,9 +59,6 @@ namespace Samples.ConsoleFramework
                 {
                     Console.WriteLine(item.Name);
                 }
-
-                Console.WriteLine("Press any key to exit...");
-                Console.ReadKey();
             }
 
 

--- a/samples/Samples.ConsoleFramework/Program.cs
+++ b/samples/Samples.ConsoleFramework/Program.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections;
+using System.Data.SqlClient;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace Samples.ConsoleFramework
 {
@@ -6,15 +10,63 @@ namespace Samples.ConsoleFramework
     {
         private static void Main(string[] args)
         {
-            new Program().Run();
+            object output = new Program().Run();
+
+            var serializer = JsonSerializer.CreateDefault();
+            serializer.Formatting = Formatting.Indented;
+            serializer.Serialize(Console.Out, output);
+
+            Console.WriteLine();
         }
 
-        private void Run()
+        private object Run()
         {
-            Console.WriteLine($"1 + 2 = {new ExampleLibrary.Class1().Add(1, 2)}");
-            Console.WriteLine($"1 * 2 = {new ExampleLibrary.Class1().Multiply(1, 2)}");
-            Console.WriteLine($"1 / 2 = {new ExampleLibrary.Class1().Divide(1, 2)}");
-            Console.ReadLine();
+            var prefixes = new[] { "COR_", "CORECLR_", "DATADOG_" };
+
+            var environmentVariables = from entry in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
+                                       from prefix in prefixes
+                                       let key = ((string)entry.Key).ToUpperInvariant()
+                                       where key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase)
+                                       select new
+                                       {
+                                           Key = key,
+                                           entry.Value
+                                       };
+
+            var dictionary = environmentVariables.ToDictionary(v => v.Key, v => v.Value);
+            int addResult = new ExampleLibrary.Class1().Add(1, 2);
+
+            dictionary.Add("ProfilerAttached", Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached);
+            dictionary.Add("AddResult", addResult);
+
+
+            using (var db = new BloggingContext())
+            {
+                // Create and save a new Blog
+                Console.Write("Enter a name for a new Blog: ");
+                var name = Console.ReadLine();
+
+                var blog = new Blog { Name = name };
+                db.Blogs.Add(blog);
+                db.SaveChanges();
+
+                // Display all Blogs from the database
+                var query = from b in db.Blogs
+                            orderby b.Name
+                            select b;
+
+                Console.WriteLine("All blogs in the database:");
+                foreach (var item in query)
+                {
+                    Console.WriteLine(item.Name);
+                }
+
+                Console.WriteLine("Press any key to exit...");
+                Console.ReadKey();
+            }
+
+
+            return dictionary;
         }
     }
 }

--- a/samples/Samples.ConsoleFramework/Program.cs
+++ b/samples/Samples.ConsoleFramework/Program.cs
@@ -43,8 +43,7 @@ namespace Samples.ConsoleFramework
             using (var db = new BloggingContext())
             {
                 // Create and save a new Blog
-                Console.Write("Enter a name for a new Blog: ");
-                var name = Console.ReadLine();
+                var name = "test-1";
 
                 var blog = new Blog { Name = name };
                 db.Blogs.Add(blog);

--- a/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
+++ b/samples/Samples.ConsoleFramework/Samples.ConsoleFramework.csproj
@@ -56,7 +56,18 @@
     <OutputPath>bin\x64\Debug\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files\dotnet\sdk\NuGetFallbackFolder\newtonsoft.json\9.0.1\lib\netstandard1.0\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -66,11 +77,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">

--- a/samples/Samples.ConsoleFramework/packages.config
+++ b/samples/Samples.ConsoleFramework/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.2.0" targetFramework="net472" />
+</packages>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// SqlServer handles tracing System.Data.SqlClient
+    /// </summary>
+    public static class SqlServer
+    {
+        private static object originalExecuteReaderLock = new object();
+        private static MethodInfo originalExecuteReader;
+
+        /// <summary>
+        /// ExecuteReader traces any SQL call.
+        /// </summary>
+        /// <param name="this">The "this" pointer for the method call.</param>
+        /// <param name="behavior">The behavior.</param>
+        /// <param name="method">The method.</param>
+        /// <returns>The original methods return.</returns>
+        public static object ExecuteReader(dynamic @this, int behavior, string method)
+        {
+            var originalMethod = GetOriginalExecuteReader(@this);
+            object result = originalMethod.Invoke(@this, new object[] { behavior, method });
+            Console.WriteLine($"{@this}, {behavior}, {method}, {result}");
+            return result;
+        }
+
+        private static MethodInfo GetOriginalExecuteReader(dynamic @this)
+        {
+            if (originalExecuteReader != null)
+            {
+                return originalExecuteReader;
+            }
+
+            lock (originalExecuteReaderLock)
+            {
+                if (originalExecuteReader != null)
+                {
+                    return originalExecuteReader;
+                }
+
+                var systemDataAssembly = AppDomain.CurrentDomain.GetAssemblies().Single(asm => asm.GetName().Name == "System.Data");
+                var commandBehaviorType = systemDataAssembly.GetType("System.Data.CommandBehavior");
+
+                Type thisType = @this.GetType();
+                originalExecuteReader = thisType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic).
+                    Where(m => m.Name == "ExecuteReader").
+                    Where(m => m.GetParameters().Length == 2).
+                    First();
+
+                return originalExecuteReader;
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -11,6 +11,7 @@
 namespace trace {
 
 const size_t kNameMaxSize = 1024;
+const size_t kSignatureMaxSize = 1024;
 const ULONG kEnumeratorMax = 256;
 
 template <typename T>
@@ -200,12 +201,18 @@ struct FunctionInfo {
   mdToken id;
   std::wstring name;
   TypeInfo type;
+  std::vector<BYTE> signature;
 
   FunctionInfo() : id(0), name(L""), type({}) {}
-  FunctionInfo(mdToken id, std::wstring name, TypeInfo type)
-      : id(id), name(name), type(type) {}
+  FunctionInfo(mdToken id, std::wstring name, TypeInfo type,
+               const std::vector<BYTE>& signature)
+      : id(id), name(name), type(type), signature(signature) {}
 
   inline bool IsValid() const { return id != 0; }
+
+  inline size_t NumberOfArguments() const {
+    return signature.size() > 1 ? size_t(signature[1]) : 0;
+  }
 };
 
 AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -248,25 +248,41 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
         continue;
       }
 
-      // if the target matches by type name and method name
-      if (method_replacement.target_method.type_name == target.type.name &&
-          method_replacement.target_method.method_name == target.name) {
-        // replace with a call to the instrumentation wrapper
-        INT32 original_argument = pInstr->m_Arg32;
-        pInstr->m_opcode = CEE_CALL;
-        pInstr->m_Arg32 = wrapper_method_ref;
-
-        modified = true;
-
-        LOG_APPEND(L"JITCompilationStarted() replaced calls from "
-                   << caller.type.name << "." << caller.name << "() to "
-                   << method_replacement.target_method.type_name << "."
-                   << method_replacement.target_method.method_name << "() "
-                   << HEX(original_argument) << " with calls to "
-                   << method_replacement.wrapper_method.type_name << "."
-                   << method_replacement.wrapper_method.method_name << "() "
-                   << HEX(wrapper_method_ref) << ".");
+      // make sure the type and method names match
+      if (method_replacement.target_method.type_name != target.type.name ||
+          method_replacement.target_method.method_name != target.name) {
+        continue;
       }
+
+      // make sure the calling convention matches
+      if (method_replacement.target_method.method_signature.data.size() > 0 &&
+          method_replacement.target_method.method_signature.data[0] !=
+              target.signature[0]) {
+        continue;
+      }
+
+      // make sure the number of arguments match
+      if (method_replacement.target_method.method_signature.data.size() > 1 &&
+          method_replacement.target_method.method_signature.data[1] !=
+              target.signature[1]) {
+        continue;
+      }
+
+      // replace with a call to the instrumentation wrapper
+      INT32 original_argument = pInstr->m_Arg32;
+      pInstr->m_opcode = CEE_CALL;
+      pInstr->m_Arg32 = wrapper_method_ref;
+
+      modified = true;
+
+      LOG_APPEND(L"JITCompilationStarted() replaced calls from "
+                 << caller.type.name << "." << caller.name << "() to "
+                 << method_replacement.target_method.type_name << "."
+                 << method_replacement.target_method.method_name << "() "
+                 << HEX(original_argument) << " with calls to "
+                 << method_replacement.wrapper_method.type_name << "."
+                 << method_replacement.wrapper_method.method_name << "() "
+                 << HEX(wrapper_method_ref) << ".");
     }
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -14,8 +14,14 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
   assembly_metadata.usMinorVersion = assembly_ref.version.minor;
   assembly_metadata.usBuildNumber = assembly_ref.version.build;
   assembly_metadata.usRevisionNumber = assembly_ref.version.revision;
-  assembly_metadata.szLocale = const_cast<wchar_t*>(assembly_ref.locale.data());
-  assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
+  if (assembly_ref.locale == L"neutral") {
+    assembly_metadata.szLocale = nullptr;
+    assembly_metadata.cbLocale = 0;
+  } else {
+    assembly_metadata.szLocale =
+        const_cast<wchar_t*>(assembly_ref.locale.data());
+    assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
+  }
 
   LOG_APPEND("EmitAssemblyRef " << assembly_ref.str());
 

--- a/src/Datadog.Trace/SpanTypes.cs
+++ b/src/Datadog.Trace/SpanTypes.cs
@@ -6,6 +6,11 @@ namespace Datadog.Trace
     public static class SpanTypes
     {
         /// <summary>
+        /// The span type for a sql database.
+        /// </summary>
+        public const string Sql = "sql";
+
+        /// <summary>
         /// The span type for a web integration.
         /// </summary>
         public const string Web = "web";


### PR DESCRIPTION
This adds a SQLServer integration for all calls to ExecuteReader. 

Other changes:
- `FunctionInfo` now includes a signature. For now we only check the number of arguments, but that at least gives us some way to distinguish between different methods.
- For `neutral` assembly references, pass it in as the empty string. This was throwing of DB access for some reason.

I still need to add tests, so this is a WIP.