### PR TITLE
allow more time for slow test

### DIFF
--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             span.Finish();
 
             double durationDifference = Math.Abs((((OpenTracingSpan)span).Duration - expectedDuration).TotalMilliseconds);
-            Assert.True(durationDifference < 10);
+            Assert.True(durationDifference < 20);
         }
 
         /*


### PR DESCRIPTION
One unit test failed due to [slowish CI run](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/results?buildId=273&view=logs), so I bumped the threshold from 10 to 20ms.