### PR TITLE
Change property name for installer version

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -14,24 +14,24 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <!-- Custom Version property for the generated installer,
-         value is set to constant ProductVersion below and
-         accessed as $(var.ProductVersion) from WiX files.
+    <!-- Custom InstallerVersion property for the generated installer,
+         value is set to build constant InstallerVersion below and
+         accessed as $(var.InstallerVersion) from WiX files.
          This is the default value is one is not specified when building. -->
-    <Version Condition="'$(Version)'==''">0.2.2</Version>
-    <OutputName>DatadogDotNetTracing-$(Version)-$(Platform)-$(Configuration)</OutputName>
+    <InstallerVersion Condition="'$(InstallerVersion)'==''">0.2.2</InstallerVersion>
+    <OutputName>DatadogDotNetTracing-$(InstallerVersion)-$(Platform)-$(Configuration)</OutputName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <DefineConstants>Debug;ProductVersion=$(Version)</DefineConstants>
+    <DefineConstants>Debug;InstallerVersion=$(InstallerVersion)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DefineConstants>ProductVersion=$(Version)</DefineConstants>
+    <DefineConstants>InstallerVersion=$(InstallerVersion)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
-    <DefineConstants>Debug;ProductVersion=$(Version)</DefineConstants>
+    <DefineConstants>Debug;InstallerVersion=$(InstallerVersion)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
-    <DefineConstants>ProductVersion=$(Version)</DefineConstants>
+    <DefineConstants>InstallerVersion=$(InstallerVersion)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Product.wxs" />

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -5,7 +5,7 @@
   <Product Id="*"
            Name="$(var.ProductName)"
            Language="1033"
-           Version="$(var.ProductVersion)"
+           Version="$(var.InstallerVersion)"
            Manufacturer="$(var.ArpManufacturer)"
            UpgradeCode="fc228e86-eae2-4c2a-ae82-135b718c269e">
     <Package InstallerVersion="200"


### PR DESCRIPTION
This PR changes the wixproj property name for installer version from `<Version>` to `<InstallerVersion>` to avoid conflict with NuGet packages when built during the same `msbuild` call. Although we usually want them to have the same version, NuGet is more strict in what it will allow for version suffixes, so they need to be slightly different.