### PR TITLE
Use EF Core in sample app

### DIFF
--- a/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
+++ b/samples/Samples.ConsoleCore/Samples.ConsoleCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net452;net46;net47;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net47;netcoreapp2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>

--- a/samples/Samples.SqlServer/Models.cs
+++ b/samples/Samples.SqlServer/Models.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Data.Entity;
-using System.Text;
+using Microsoft.EntityFrameworkCore;
 
 namespace Samples.SqlServer
 {
@@ -27,5 +26,11 @@ namespace Samples.SqlServer
     {
         public DbSet<Blog> Blogs { get; set; }
         public DbSet<Post> Posts { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            // use LocalDB for ease of use
+            optionsBuilder.UseSqlServer(@"Server=(localdb)\MSSQLLocalDB;Database=BlogDatabase;Integrated Security=true");
+        }
     }
 }

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -9,6 +9,9 @@ namespace Samples.SqlServer
         {
             using (var db = new BloggingContext())
             {
+                // create database if missing
+                db.Database.EnsureCreated();
+
                 var name = "test";
 
                 var blog = (from b in db.Blogs where b.Name == name select b).FirstOrDefault();

--- a/samples/Samples.SqlServer/Samples.SqlServer.csproj
+++ b/samples/Samples.SqlServer/Samples.SqlServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net452;net46;net47;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net47;netcoreapp2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
@@ -15,13 +15,9 @@
     <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1"/>
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.2.0" />
-    <PackageReference Include="HttpMock" Version="2.3.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string HttpContextKey = "__Datadog.Trace.ClrProfiler.Integrations.AspNetMvc5Integration";
         private const string RequestOperationName = "aspnet_mvc.request";
 
-        private static readonly Type ContollerContextType;
+        private static readonly Type ControllerContextType;
 
         private readonly HttpContextBase _httpContext;
         private readonly Scope _scope;
@@ -26,11 +26,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 Assembly assembly = Assembly.Load("System.Web.Mvc");
-                ContollerContextType = assembly.GetType("System.Web.Mvc.ControllerContext", throwOnError: false);
+                ControllerContextType = assembly.GetType("System.Web.Mvc.ControllerContext", throwOnError: false);
             }
             catch
             {
-                ContollerContextType = null;
+                ControllerContextType = null;
             }
         }
 
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="controllerContextObj">The System.Web.Mvc.ControllerContext that was passed as an argument to the instrumented method.</param>
         public AspNetMvc5Integration(object controllerContextObj)
         {
-            if (controllerContextObj == null || ContollerContextType == null)
+            if (controllerContextObj == null || ControllerContextType == null)
             {
                 // bail out early
                 return;
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
-                if (controllerContextObj.GetType() != ContollerContextType)
+                if (controllerContextObj.GetType() != ControllerContextType)
                 {
                     return;
                 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/BuildParameters.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/BuildParameters.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
 #if NET452
         public const string TargetFramework = "net452";
-#elif NET46
-        public const string TargetFramework = "net46";
+#elif NET461
+        public const string TargetFramework = "net461";
 #elif NET47
         public const string TargetFramework = "net47";
 #elif NETCOREAPP2_0

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ConsoleCoreTests.cs
@@ -21,7 +21,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [Fact]
-        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1025:CodeMustNotContainMultipleWhitespaceInARow", Justification = "Reviewed.")]
         public void ProfilerAttached()
         {
             string standardOutput;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net46;net47;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net47;netcoreapp2.0</TargetFrameworks>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
@@ -1,11 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
-using MessagePack;
 using Xunit;
+
+// EFCore targets netstandard2.0, so it requires net461 or higher or netcoreapp2.0 or higher
+#if !NET452
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
@@ -34,3 +30,5 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
     }
 }
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -65,9 +65,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public static Process StartSample(string name)
         {
             // get path to native profiler dll
-            if (!File.Exists(GetProfilerDllPath()))
+            string profilerDllPath = GetProfilerDllPath();
+            if (!File.Exists(profilerDllPath))
             {
-                throw new Exception($"profiler not found: {GetProfilerDllPath()}");
+                throw new Exception($"profiler not found: {profilerDllPath}");
             }
 
             // get path to sample app that the profiler will attach to
@@ -85,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 BuildParameters.CoreClr,
                 integrationPaths,
                 Instrumentation.ProfilerClsid,
-                GetProfilerDllPath());
+                profilerDllPath);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
@@ -39,23 +37,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public static string GetProfilerDllPath()
         {
-            return Path.Combine(new string[]
-            {
-                    GetSolutionDirectory(),
-                    "src",
-                    "Datadog.Trace.ClrProfiler.Native",
-                    "bin",
-                    BuildParameters.Configuration,
-                    GetPlatform(),
-                    "Datadog.Trace.ClrProfiler.Native.dll"
-            });
+            return Path.Combine(
+                GetSolutionDirectory(),
+                "src",
+                "Datadog.Trace.ClrProfiler.Native",
+                "bin",
+                BuildParameters.Configuration,
+                GetPlatform(),
+                "Datadog.Trace.ClrProfiler.Native.dll");
         }
 
         public static string GetSampleDllPath(string name)
         {
             string appFileName = BuildParameters.CoreClr ? $"Samples.{name}.dll" : $"Samples.{name}.exe";
-            return Path.Combine(new string[]
-            {
+            return Path.Combine(
                 GetSolutionDirectory(),
                 "samples",
                 $"Samples.{name}",
@@ -64,8 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 BuildParameters.Configuration,
                 BuildParameters.TargetFramework,
                 GetRuntimeIdentifier(),
-                appFileName,
-            });
+                appFileName);
         }
 
         public static Process StartSample(string name)


### PR DESCRIPTION
- Use EF Core instead of classic EF6 in `Samples.SqlServer` so we can run it on both .NET Framework and .NET Core
- drop target `net45` and replace `net46` with `net461` in sample apps and integration tests because that's the oldest .NET Framework version that supports .NET Standard 2.0
- call `GetProfilerDllPath()` only once from `StartSample()`
- sneak fix: typo in private field name
