### PR TITLE
integration test refactor, support SqlClient on .NET Core

### DIFF
--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -9,3 +9,5 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:UsingDirectivesMustBePlacedWithinNamespace", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments must not be followed by blank line", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:Single-line comment must be preceded by blank line", Justification = "Reviewed.")]

--- a/integrations.json
+++ b/integrations.json
@@ -84,13 +84,13 @@
           "assembly": "System.Data",
           "type": "System.Data.SqlClient.SqlCommand",
           "method": "ExecuteReader",
-          "signature": [ 32, 2, 12, 82, 8, 11, 82, 91, 14 ]
+          "signature": [ 32, 1, 12, 87, 12, 11, 92 ]
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.2.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.SqlServer",
           "method": "ExecuteReader",
-          "signature": [ 0, 3, 28, 28, 8, 14 ]
+          "signature": [ 0, 2, 28, 28, 8 ]
         }
       }
     ]

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
     <Version>0.2.2-alpha</Version>
     <RootNamespace>Datadog.Trace.ClrProfiler</RootNamespace>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -16,24 +17,42 @@ namespace Datadog.Trace.ClrProfiler
         /// <typeparam name="TDelegate">A <see cref="Delegate"/> type with the signature of the method to call.</typeparam>
         /// <param name="type">The <see cref="Type"/> that contains the method.</param>
         /// <param name="methodName">The name of the method.</param>
-        /// <param name="returnType">The return <see cref="Type"/> of the method.</param>
-        /// <param name="parameterTypes">An array with the <see cref="Type"/> of each of the method's parameters, in order.</param>
-        /// <param name="isVirtual"><c>true</c> if the dyanmic method should use a virtual method call, <c>false</c> otherwise.</param>
+        /// <param name="isVirtual"><c>true</c> if the dynamic method should use a virtual method call, <c>false</c> otherwise.</param>
         /// <returns>A <see cref="Delegate"/> that can be used to execute the dynamic method.</returns>
-        public static Delegate CreateMethodCallDelegate<TDelegate>(
+        public static TDelegate CreateMethodCallDelegate<TDelegate>(
             Type type,
             string methodName,
-            Type returnType,
-            Type[] parameterTypes,
             bool isVirtual)
+            where TDelegate : Delegate
         {
-            MethodInfo methodInfo = type.GetMethod(methodName, BindingFlags.Static | BindingFlags.Public);
+            Type delegateType = typeof(TDelegate);
+            Type[] genericTypeArguments = delegateType.GenericTypeArguments;
+            Type returnType;
+            Type[] parameterTypes;
+
+            if (delegateType.Name.StartsWith("Func`"))
+            {
+                // last generic parameter
+                returnType = genericTypeArguments.Last();
+                parameterTypes = genericTypeArguments.Take(genericTypeArguments.Length - 1).ToArray();
+            }
+            else if (delegateType.Name.StartsWith("Action`"))
+            {
+                returnType = typeof(void);
+                parameterTypes = genericTypeArguments;
+            }
+            else
+            {
+                throw new Exception($"Only Func<> or Action<> are supported in {nameof(CreateMethodCallDelegate)}.");
+            }
+
+            MethodInfo methodInfo = type.GetMethod(methodName, parameterTypes);
 
             if (methodInfo == null)
             {
                 // method not found
                 // TODO: logging
-                return null;
+                return default;
             }
 
             var dynamicMethod = new DynamicMethod(methodName, returnType, parameterTypes);
@@ -70,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler
             ilGenerator.Emit(isVirtual ? OpCodes.Callvirt : OpCodes.Call, methodInfo);
             ilGenerator.Emit(OpCodes.Ret);
 
-            return dynamicMethod.CreateDelegate(typeof(TDelegate));
+            return (TDelegate)dynamicMethod.CreateDelegate(delegateType);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -191,7 +191,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             return DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
                 type,
                 methodName,
-                false);
+                true);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -188,21 +188,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static Action<object, object, object, object> CreateDelegate(Type type, string methodName)
         {
-            Type returnType = typeof(void);
-
-            Type[] parameterTypes =
-            {
-                typeof(object),
-                typeof(object),
-                typeof(object),
-                typeof(object),
-            };
-
-            return (Action<object, object, object, object>)DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
+            return DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
                 type,
                 methodName,
-                returnType,
-                parameterTypes,
                 false);
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -83,7 +83,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     Assembly assembly = actionDescriptor.GetType().GetTypeInfo().Assembly;
                     Type type = assembly.GetType("Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions");
-                    _beforeAction = CreateDelegate(type, "BeforeAction");
+
+                    _beforeAction = DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
+                        type,
+                        "BeforeAction",
+                        isStatic: true);
                 }
             }
             catch
@@ -134,7 +138,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 if (_afterAction == null)
                 {
                     Type type = actionDescriptor.GetType().Assembly.GetType("Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions");
-                    _afterAction = CreateDelegate(type, "AfterAction");
+
+                    _afterAction = DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
+                        type,
+                        "AfterAction",
+                        isStatic: true);
                 }
             }
             catch
@@ -184,14 +192,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 _scope?.Dispose();
             }
-        }
-
-        private static Action<object, object, object, object> CreateDelegate(Type type, string methodName)
-        {
-            return DynamicMethodBuilder.CreateMethodCallDelegate<Action<object, object, object, object>>(
-                type,
-                methodName,
-                true);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -26,18 +27,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scope.Span.Type = SpanTypes.Sql;
                 scope.Span.SetTag(Tags.SqlDatabase, @this.Connection.ConnectionString);
 
-                dynamic result;
                 try
                 {
-                    result = @this.ExecuteReader(behavior, method);
+                    return @this.ExecuteReader((CommandBehavior)behavior, method);
                 }
                 catch (Exception ex)
                 {
                     scope.Span.SetException(ex);
                     throw;
                 }
-
-                return result;
             }
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -10,6 +10,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     public static class SqlServer
     {
         private const string OperationName = "sqlserver.query";
+        private static Func<object, CommandBehavior, object> _executeReader;
 
         /// <summary>
         /// ExecuteReader traces any SQL call.
@@ -21,6 +22,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             var command = (DbCommand)@this;
 
+            if (_executeReader == null)
+            {
+                _executeReader = DynamicMethodBuilder.CreateMethodCallDelegate<Func<object, CommandBehavior, object>>(
+                    command.GetType(),
+                    "ExecuteReader",
+                    isStatic: false);
+            }
+
             using (var scope = Tracer.Instance.StartActive(OperationName))
             {
                 // set the scope properties
@@ -31,12 +40,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 try
                 {
-                    var dynamicMethod = DynamicMethodBuilder.CreateMethodCallDelegate<Func<object, CommandBehavior, object>>(
-                        command.GetType(),
-                        "ExecuteReader",
-                        false);
-
-                    return dynamicMethod(command, (CommandBehavior)behavior);
+                    return _executeReader(command, (CommandBehavior)behavior);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -1,9 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessResult.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessResult.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Diagnostics;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class ProcessResult : IDisposable
+    {
+        public ProcessResult(
+            Process process,
+            string standardOutput,
+            string standardError,
+            int exitCode)
+        {
+            Process = process;
+            StandardOutput = standardOutput;
+            StandardError = standardError;
+            ExitCode = exitCode;
+        }
+
+        public Process Process { get; }
+
+        public string StandardOutput { get; }
+
+        public string StandardError { get; }
+
+        public int ExitCode { get; }
+
+        public void Dispose()
+        {
+            Process?.Dispose();
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Xunit.Abstractions;
 
 // EFCore targets netstandard2.0, so it requires net461 or higher or netcoreapp2.0 or higher
 #if !NET452
@@ -7,16 +8,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class SqlServerTests : TestHelper
     {
+        public SqlServerTests(ITestOutputHelper output)
+            : base("SqlServer", output)
+        {
+        }
+
         [Fact]
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
             using (var agent = new MockTracerAgent())
+            using (ProcessResult processResult = RunSampleAndWaitForExit())
             {
-                using (var process = StartSample("SqlServer"))
-                {
-                    process.WaitForExit();
-                }
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.GetSpans();
                 Assert.True(spans.Count > 1);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -116,8 +116,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             process.WaitForExit();
             int exitCode = process.ExitCode;
 
-            Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
-            Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+            if (!string.IsNullOrWhiteSpace(standardOutput))
+            {
+                Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(standardError))
+            {
+                Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+            }
 
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -4,30 +4,48 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public abstract class TestHelper
     {
-        public static string GetPlatform()
+        protected TestHelper(string sampleAppName, ITestOutputHelper output)
+        {
+            SampleAppName = sampleAppName;
+            Output = output;
+
+            Output.WriteLine($"Platform: {GetPlatform()}");
+            Output.WriteLine($"Configuration: {BuildParameters.Configuration}");
+            Output.WriteLine($"TargetFramework: {BuildParameters.TargetFramework}");
+            Output.WriteLine($".NET Core: {BuildParameters.CoreClr}");
+            Output.WriteLine($"Application: {GetSampleApplicationPath()}");
+            Output.WriteLine($"Profiler DLL: {GetProfilerDllPath()}");
+        }
+
+        protected string SampleAppName { get; }
+
+        protected ITestOutputHelper Output { get; }
+
+        public string GetPlatform()
         {
             return Environment.Is64BitProcess ? "x64" : "x86";
         }
 
-        public static string GetOS()
+        public string GetOS()
         {
             return Environment.OSVersion.Platform == PlatformID.Win32NT ? "win" :
-                 Environment.OSVersion.Platform == PlatformID.Unix ? "linux" :
-                 Environment.OSVersion.Platform == PlatformID.MacOSX ? "osx" :
-                                                                        string.Empty;
+                   Environment.OSVersion.Platform == PlatformID.Unix    ? "linux" :
+                   Environment.OSVersion.Platform == PlatformID.MacOSX  ? "osx" :
+                                                                          string.Empty;
         }
 
-        public static string GetRuntimeIdentifier()
+        public string GetRuntimeIdentifier()
         {
             return BuildParameters.CoreClr ? string.Empty : $"{GetOS()}-{GetPlatform()}";
         }
 
-        public static string GetSolutionDirectory()
+        public string GetSolutionDirectory()
         {
             string[] pathParts = Environment.CurrentDirectory.ToLowerInvariant().Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
             int directoryDepth = pathParts.Length - pathParts.ToList().IndexOf("test");
@@ -35,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return Path.GetFullPath(relativeBasePath);
         }
 
-        public static string GetProfilerDllPath()
+        public string GetProfilerDllPath()
         {
             return Path.Combine(
                 GetSolutionDirectory(),
@@ -47,13 +65,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 "Datadog.Trace.ClrProfiler.Native.dll");
         }
 
-        public static string GetSampleDllPath(string name)
+        public string GetSampleApplicationPath()
         {
-            string appFileName = BuildParameters.CoreClr ? $"Samples.{name}.dll" : $"Samples.{name}.exe";
+            string appFileName = BuildParameters.CoreClr ? $"Samples.{SampleAppName}.dll" : $"Samples.{SampleAppName}.exe";
             return Path.Combine(
                 GetSolutionDirectory(),
                 "samples",
-                $"Samples.{name}",
+                $"Samples.{SampleAppName}",
                 "bin",
                 GetPlatform(),
                 BuildParameters.Configuration,
@@ -62,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 appFileName);
         }
 
-        public static Process StartSample(string name)
+        public Process StartSample()
         {
             // get path to native profiler dll
             string profilerDllPath = GetProfilerDllPath();
@@ -72,21 +90,36 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             // get path to sample app that the profiler will attach to
-            var sampleDllPath = GetSampleDllPath(name);
-            if (!File.Exists(sampleDllPath))
+            string sampleAppPath = GetSampleApplicationPath();
+            if (!File.Exists(sampleAppPath))
             {
-                throw new Exception($"application not found: {sampleDllPath}");
+                throw new Exception($"application not found: {sampleAppPath}");
             }
 
             // get full paths to integration definitions
             IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*.json").Select(Path.GetFullPath);
 
             return ProfilerHelper.StartProcessWithProfiler(
-                sampleDllPath,
+                sampleAppPath,
                 BuildParameters.CoreClr,
                 integrationPaths,
                 Instrumentation.ProfilerClsid,
                 profilerDllPath);
+        }
+
+        public ProcessResult RunSampleAndWaitForExit()
+        {
+            Process process = StartSample();
+
+            string standardOutput = process.StandardOutput.ReadToEnd();
+            string standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            int exitCode = process.ExitCode;
+
+            Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+
+            return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
     }
 }

--- a/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -52,7 +52,9 @@ namespace Datadog.Trace.TestHelpers
                 startInfo = new ProcessStartInfo(appPath);
             }
 
-            Environment.SetEnvironmentVariable("DATADOG_INTEGRATIONS", string.Join(";", integrationPaths));
+            string integrations = string.Join(";", integrationPaths);
+            Environment.SetEnvironmentVariable("DD_INTEGRATIONS", integrations);
+            Environment.SetEnvironmentVariable("DATADOG_INTEGRATIONS", integrations);
 
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
@@ -79,6 +81,8 @@ namespace Datadog.Trace.TestHelpers
                                            "COR_PROFILER_PATH",
 
                                            // Datadog
+                                           "DD_PROFILER_PROCESSES",
+                                           "DD_INTEGRATIONS",
                                            "DATADOG_PROFILER_PROCESSES",
                                            "DATADOG_INTEGRATIONS",
                                        };

--- a/test/GlobalSuppressions.cs
+++ b/test/GlobalSuppressions.cs
@@ -7,3 +7,4 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:EnableXmlDocumentationOutput", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1025:Code must not contain multiple whitespace in a row", Justification = "Reviewed. Used for pretty formatting.")]


### PR DESCRIPTION
- integration test refactor
- support SqlClient on .NET Core
- use dynamic methods (emitting IL) instead of `dynamic`