### PR TITLE
SQL Server integration redux

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -108,7 +108,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.I
 		{086FF8A0-9CEE-470A-9751-78B0F1340649} = {086FF8A0-9CEE-470A-9751-78B0F1340649}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.SqlServer", "samples\Samples.SqlServer\Samples.SqlServer.csproj", "{086FF8A0-9CEE-470A-9751-78B0F1340649}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SqlServer", "samples\Samples.SqlServer\Samples.SqlServer.csproj", "{086FF8A0-9CEE-470A-9751-78B0F1340649}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C0C8D381-D6B9-4C76-9428-F40F2FA93A9A} = {C0C8D381-D6B9-4C76-9428-F40F2FA93A9A}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/devenv.bat
+++ b/devenv.bat
@@ -4,10 +4,10 @@ rem by enabling the Profiler API and starting Visual Studio.
 rem Any process started by VS will inherit the environment variables,
 rem enabling the profiler for apps run from VS, including while debugging.
 
-rem Clear previous values, if any
-set profiler_platform=
-set profiler_configuration=
-set start_visual_studio=
+rem Set default values
+set profiler_platform=x64
+set profiler_configuration=Debug
+set start_visual_studio=true
 
 :next_argument
 if not "%1" == "" (
@@ -36,10 +36,6 @@ if not "%1" == "" (
     shift
     goto next_argument
 )
-
-rem Set default values
-if "%profiler_configuration%" == "" set profiler_configuration=Debug
-if "%profiler_platform%" == "" set profiler_platform=x64
 
 echo Enabling profiler for "%profiler_configuration%/%profiler_platform%".
 

--- a/integrations.json
+++ b/integrations.json
@@ -92,7 +92,7 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.2.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.SqlServer",
-          "method": "ExecuteReader",
+          "method": "ExecuteReaderWithMethod",
           "signature": [ 0, 3, 28, 28, 8, 14 ]
         }
       },

--- a/integrations.json
+++ b/integrations.json
@@ -99,7 +99,7 @@
       {
         "caller": {},
         "target": {
-          "assembly": "System.Data",
+          "assembly": "System.Data.SqlClient",
           "type": "System.Data.SqlClient.SqlCommand",
           "method": "ExecuteReader",
           "signature": [ 32, 1, 12, 87, 12, 11, 92 ]

--- a/integrations.json
+++ b/integrations.json
@@ -79,7 +79,10 @@
     "name": "SqlServer",
     "method_replacements": [
        {
-        "caller": {},
+        "caller": {
+          "assembly": "System.Data",
+          "type": "System.Data.SqlClient.SqlCommand"
+        },
         "target": {
           "assembly": "System.Data",
           "type": "System.Data.SqlClient.SqlCommand",

--- a/integrations.json
+++ b/integrations.json
@@ -78,6 +78,21 @@
   {
     "name": "SqlServer",
     "method_replacements": [
+       {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.SqlClient.SqlCommand",
+          "method": "ExecuteReader",
+          "signature": [ 32, 2, 12, 82, 8, 11, 82, 91, 14 ]
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.2.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.SqlServer",
+          "method": "ExecuteReader",
+          "signature": [ 0, 3, 28, 28, 8, 14 ]
+        }
+      },
       {
         "caller": {},
         "target": {

--- a/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler
                 return null;
             }
 
-            var dynamicMethod = new DynamicMethod(methodName, returnType, parameterTypes);
+            var dynamicMethod = new DynamicMethod(methodName, returnType, parameterTypes, type);
             ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
 
             for (int argumentIndex = 0; argumentIndex < parameterTypes.Length; argumentIndex++)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -11,6 +11,40 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         private const string OperationName = "sqlserver.query";
         private static Func<object, CommandBehavior, object> _executeReader;
+        private static Func<object, CommandBehavior, string, object> _executeReaderWithMethod;
+
+        /// <summary>
+        /// ExecuteReader traces any SQL call.
+        /// </summary>
+        /// <param name="this">The "this" pointer for the method call.</param>
+        /// <param name="behavior">The behavior.</param>
+        /// <param name="method">The method.</param>
+        /// <returns>The original methods return.</returns>
+        public static object ExecuteReader(dynamic @this, int behavior, string method)
+        {
+            var command = (DbCommand)@this;
+
+            if (_executeReaderWithMethod == null)
+            {
+                _executeReaderWithMethod = DynamicMethodBuilder.CreateMethodCallDelegate<Func<object, CommandBehavior, string, object>>(
+                    command.GetType(),
+                    "ExecuteReader",
+                    isStatic: false);
+            }
+
+            using (var scope = CreateScope(command))
+            {
+                try
+                {
+                    return _executeReaderWithMethod(command, (CommandBehavior)behavior, method);
+                }
+                catch (Exception ex)
+                {
+                    scope.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
 
         /// <summary>
         /// ExecuteReader traces any SQL call.
@@ -30,14 +64,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     isStatic: false);
             }
 
-            using (var scope = Tracer.Instance.StartActive(OperationName))
+            using (var scope = CreateScope(command))
             {
-                // set the scope properties
-                // - row count is not supported so we don't set it
-                scope.Span.ResourceName = command.CommandText;
-                scope.Span.Type = SpanTypes.Sql;
-                scope.Span.SetTag(Tags.SqlDatabase, command.Connection?.ConnectionString);
-
                 try
                 {
                     return _executeReader(command, (CommandBehavior)behavior);
@@ -48,6 +76,19 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     throw;
                 }
             }
+        }
+
+        private static Scope CreateScope(DbCommand command)
+        {
+            var scope = Tracer.Instance.StartActive(OperationName);
+
+            // set the scope properties
+            // - row count is not supported so we don't set it
+            scope.Span.ResourceName = command.CommandText;
+            scope.Span.Type = SpanTypes.Sql;
+            scope.Span.SetTag(Tags.SqlDatabase, command.Connection?.ConnectionString);
+
+            return scope;
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/SqlServer.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="behavior">The behavior.</param>
         /// <param name="method">The method.</param>
         /// <returns>The original methods return.</returns>
-        public static object ExecuteReader(dynamic @this, int behavior, string method)
+        public static object ExecuteReaderWithMethod(dynamic @this, int behavior, string method)
         {
             var command = (DbCommand)@this;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -26,10 +26,10 @@ HRESULT STDMETHODCALLTYPE
 CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   is_attached_ = FALSE;
 
-  auto process_name = GetCurrentProcessName();
+  const auto process_name = GetCurrentProcessName();
   auto allowed_process_names = GetEnvironmentValues(kProcessesEnvironmentName);
 
-  if (allowed_process_names.size() == 0) {
+  if (allowed_process_names.empty()) {
     LOG_APPEND(
         L"DATADOG_PROFILER_PROCESSES environment variable not set. Attaching "
         L"to any .NET process.");
@@ -246,7 +246,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       }
 
       // make sure the calling convention matches
-      if (method_replacement.target_method.method_signature.data.size() > 0 &&
+      if (!method_replacement.target_method.method_signature.data.empty() &&
           method_replacement.target_method.method_signature.data[0] !=
               target.signature[0]) {
         continue;
@@ -260,7 +260,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       }
 
       // replace with a call to the instrumentation wrapper
-      INT32 original_argument = pInstr->m_Arg32;
+      const auto original_argument = pInstr->m_Arg32;
       pInstr->m_opcode = CEE_CALL;
       pInstr->m_Arg32 = wrapper_method_ref;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -74,10 +74,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   }
 
   if (module_info.IsWindowsRuntime() ||
-      module_info.assembly.name == L"mscorlib") {
+      module_info.assembly.name == L"mscorlib" ||
+      module_info.assembly.name == L"netstandard") {
     // We cannot obtain writeable metadata interfaces on Windows Runtime modules
     // or instrument their IL. We must never try to add assembly references to
-    // mscorlib.
+    // mscorlib or netstandard.
     LOG_APPEND(L"ModuleLoadFinished() called for "
                << module_info.assembly.name << ". Skipping instrumentation.");
     return S_OK;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
@@ -58,8 +58,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private class SpanCollector
         {
-            private List<Span> _spans = new List<Span>();
-            private Task _task;
+            private readonly List<Span> _spans = new List<Span>();
+            private readonly Task _task;
 
             public SpanCollector(HttpListener listener)
             {
@@ -82,9 +82,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             private static List<Span> ToSpans(dynamic data)
             {
-                if (data is IDictionary)
+                if (data is IDictionary dict)
                 {
-                    var dict = data as IDictionary;
                     var span = new Span
                     {
                         TraceId = dict.Get<ulong>("trace_id"),
@@ -100,16 +99,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     return new List<Span> { span };
                 }
 
-                if (data is IEnumerable)
+                if (data is IEnumerable rawSpans)
                 {
-                    var rawSpans = data as IEnumerable;
                     var allSpans = new List<Span>();
-                    if (rawSpans != null)
+
+                    foreach (var rawSpan in rawSpans)
                     {
-                        foreach (var rawSpan in rawSpans)
-                        {
-                            allSpans.AddRange(ToSpans(rawSpan));
-                        }
+                        allSpans.AddRange(ToSpans(rawSpan));
                     }
 
                     return allSpans;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -11,8 +10,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class MockTracerAgent : IDisposable
     {
-        private HttpListener _listener;
-        private SpanCollector _collector;
+        private readonly HttpListener _listener;
+        private readonly SpanCollector _collector;
 
         public MockTracerAgent()
         {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
@@ -116,7 +116,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             private void Handle(HttpListener listener)
             {
-                while (true)
+                while (listener.IsListening)
                 {
                     try
                     {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MockTracerAgent.cs
@@ -77,7 +77,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             public void Wait()
             {
-                _task.Wait();
+                if (!_task.Wait(TimeSpan.FromSeconds(20)))
+                {
+                    throw new Exception("Timeout while waiting for SpanCollector loop to end.");
+                }
             }
 
             private static List<Span> ToSpans(dynamic data)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             // get full paths to integration definitions
-            IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*.json").Select(Path.GetFullPath);
+            IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
 
             return ProfilerHelper.StartProcessWithProfiler(
                 sampleAppPath,

--- a/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace Datadog.Trace.TestHelpers
 {
     public class ProfilerHelper
     {
+        private const string DotNetCoreExecutable = "dotnet.exe";
+
         public static Process StartProcessWithProfiler(
             string appPath,
             bool coreClr,
@@ -40,7 +43,10 @@ namespace Datadog.Trace.TestHelpers
                 Environment.SetEnvironmentVariable("CORECLR_PROFILER", profilerClsid);
                 Environment.SetEnvironmentVariable("CORECLR_PROFILER_PATH", profilerDllPath);
 
-                startInfo = new ProcessStartInfo("dotnet.exe", appPath);
+                Environment.SetEnvironmentVariable("DD_PROFILER_PROCESSES", DotNetCoreExecutable);
+                Environment.SetEnvironmentVariable("DATADOG_PROFILER_PROCESSES", DotNetCoreExecutable);
+
+                startInfo = new ProcessStartInfo(DotNetCoreExecutable, appPath);
             }
             else
             {
@@ -48,6 +54,10 @@ namespace Datadog.Trace.TestHelpers
                 Environment.SetEnvironmentVariable("COR_ENABLE_PROFILING", "1");
                 Environment.SetEnvironmentVariable("COR_PROFILER", profilerClsid);
                 Environment.SetEnvironmentVariable("COR_PROFILER_PATH", profilerDllPath);
+
+                string executableFileName = Path.GetFileName(appPath);
+                Environment.SetEnvironmentVariable("DD_PROFILER_PROCESSES", executableFileName);
+                Environment.SetEnvironmentVariable("DATADOG_PROFILER_PROCESSES", executableFileName);
 
                 startInfo = new ProcessStartInfo(appPath);
             }


### PR DESCRIPTION
Changes to `SqlCommand` integration:
- keep two method replacements for .NET Framework and .NET Core/Standard versions of `SqlCommand`
- allow access to private methods in `DynamicMethodBuilder`
- limit the search for calls to `ExecuteReader(CommandBehavior,string)`

Changes to integration tests:
- break out of loop when listener stops listening
- set a timeout when calling `MockTracerAgent.Wait()` to avoid hanging tests
- only look for `*integrations.json` files when loading integration definitions
- set `DD_PROFILER_PROCESSES` environment variable during integration tests to avoid profiling other child processes, like `sqlservr.exe` when using LocalDB

Sneaky changes:
- add build dependency to enforce building native dll when building `Samples.SqlServer`
- fix `devenv.bat` to start VS by default (change was not intentional), use `vs-` argument to skip
- bonus C++ clean up thanks to clang-tidy
