### PR TITLE
require integrations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -33,7 +33,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   const auto process_name = GetCurrentProcessName();
-  auto allowed_process_names = GetEnvironmentValues(kProcessesEnvironmentName);
+  const auto allowed_process_names = GetEnvironmentValues(kProcessesEnvironmentName);
 
   if (allowed_process_names.empty()) {
     LOG_APPEND(
@@ -47,7 +47,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
     if (std::find(allowed_process_names.begin(), allowed_process_names.end(),
                   process_name) == allowed_process_names.end()) {
-      LOG_APPEND(L"CorProfiler disabled: module name \""
+      LOG_APPEND(L"Profiler disabled: module name \""
                  << process_name << "\" does not match "
                  << kProcessesEnvironmentName << " environment variable.");
       return E_FAIL;
@@ -57,14 +57,14 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
       &this->info_);
   LOG_IFFAILEDRET(hr,
-                  L"CorProfiler disabled: interface ICorProfilerInfo3 or "
+                  L"Profiler disabled: interface ICorProfilerInfo3 or "
                   L"higher not found.");
 
   hr = this->info_->SetEventMask(kEventMask);
   LOG_IFFAILEDRET(hr, L"Failed to attach profiler: unable to set event mask.");
 
   // we're in!
-  LOG_APPEND(L"CorProfiler attached to process " << process_name);
+  LOG_APPEND(L"Profiler attached to process " << process_name);
   this->info_->AddRef();
   is_attached_ = true;
   profiler = this;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -26,13 +26,15 @@ HRESULT STDMETHODCALLTYPE
 CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   is_attached_ = FALSE;
 
+  const auto process_name = GetCurrentProcessName();
+  LOG_APPEND(L"Initialize() called for " << process_name);
+
   if (integrations_.empty()) {
     LOG_APPEND(L"Profiler disabled: " << kIntegrationsEnvironmentName
                                       << L" environment variable not set.");
     return E_FAIL;
   }
 
-  const auto process_name = GetCurrentProcessName();
   const auto allowed_process_names = GetEnvironmentValues(kProcessesEnvironmentName);
 
   if (allowed_process_names.empty()) {

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -26,6 +26,12 @@ HRESULT STDMETHODCALLTYPE
 CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   is_attached_ = FALSE;
 
+  if (integrations_.empty()) {
+    LOG_APPEND(L"Profiler disabled: " << kIntegrationsEnvironmentName
+                                      << L" environment variable not set.");
+    return E_FAIL;
+  }
+
   const auto process_name = GetCurrentProcessName();
   auto allowed_process_names = GetEnvironmentValues(kProcessesEnvironmentName);
 


### PR DESCRIPTION
If `DD_INTEGRATIONS` is not defined or if no integrations were loaded, then write to the log and bail out early, since there is nothing to instrument. This also makes is very clear in the logs why nothing is being instrumented.