### PR TITLE
normalize resource capitalization

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -28,8 +29,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 dynamic actionDescriptor = actionDescriptorObj;
-                string controllerName = actionDescriptor.ControllerName;
-                string actionName = actionDescriptor.ActionName;
+                string controllerName = (actionDescriptor.ControllerName as string)?.ToLowerInvariant();
+                string actionName = (actionDescriptor.ActionName as string)?.ToLowerInvariant();
                 string resourceName = $"{controllerName}.{actionName}";
 
                 _httpContext = httpContextObj;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -68,8 +68,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 string url = _httpContext.Request.RawUrl.ToLowerInvariant();
 
                 IDictionary<string, object> routeValues = controllerContext.RouteData.Values;
-                string controllerName = routeValues.GetValueOrDefault("controller") as string;
-                string actionName = routeValues.GetValueOrDefault("action") as string;
+                string controllerName = (routeValues.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
+                string actionName = (routeValues.GetValueOrDefault("action") as string)?.ToLowerInvariant();
                 string resourceName = $"{controllerName}.{actionName}";
 
                 _scope = Tracer.Instance.StartActive(RequestOperationName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -104,8 +104,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 if (controllerContext?.RouteData?.Values is IDictionary<string, object> routeValues)
                 {
-                    controller = (routeValues.GetValueOrDefault("controller") as string) ?? string.Empty;
-                    action = (routeValues.GetValueOrDefault("action") as string) ?? string.Empty;
+                    controller = (routeValues.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
+                    action = (routeValues.GetValueOrDefault("action") as string)?.ToLowerInvariant();
                 }
             }
             catch


### PR DESCRIPTION
Change the controller name and action name to lower case. Otherwise we end up using the case from the url or the defaults for the parts not specified, which can be different:

url|controller / action
-|-
/|Home (default controller) / Index (default action)
/home|home / Index (default action)
/home/index|home / index
/hOmE/inDEx|hOmE / inDEx