### PR TITLE
[WIP] don't set null tag values

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -131,7 +131,15 @@ namespace Datadog.Trace
                     _tags = new Dictionary<string, string>();
                 }
 
-                _tags[key] = value;
+                if (value == null)
+                {
+                    _tags.Remove(key);
+                }
+                else
+                {
+                    _tags[key] = value;
+                }
+
                 return this;
             }
         }


### PR DESCRIPTION
Don't set tag values to `null` because the Agent will fail to deserialize traces. Let a `null` value mean "no tag" (i.e. don't add a new tag and remove the tag if it exists), but allow tags to be explicitly set to an empty string.

Fixes #137.