### PR TITLE
Add more app info to Samples.AspNetMvc5

### DIFF
--- a/samples/Samples.AspNetMvc5/Controllers/HomeController.cs
+++ b/samples/Samples.AspNetMvc5/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Mvc;
@@ -9,7 +12,16 @@ namespace Samples.AspNetMvc5.Controllers
     {
         public ActionResult Index()
         {
-            return View();
+            var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
+
+            var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
+                          from prefix in prefixes
+                          let key = (envVar.Key as string)?.ToUpperInvariant()
+                          let value = envVar.Value as string
+                          where key.StartsWith(prefix)
+                          select new KeyValuePair<string, string>(key, value);
+
+            return View(envVars.ToList());
         }
 
         [Route("delay/{seconds}")]

--- a/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -134,6 +134,10 @@
       <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
       <Name>Datadog.Trace.ClrProfiler.Managed</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj">
+      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
+      <Name>Datadog.Trace</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/samples/Samples.AspNetMvc5/Views/Home/Index.cshtml
+++ b/samples/Samples.AspNetMvc5/Views/Home/Index.cshtml
@@ -1,5 +1,58 @@
-﻿@{
+﻿@model List<KeyValuePair<string, string>>
+
+@{
     ViewBag.Title = "Index";
 }
 
-<h1>Hello, world!</h1>
+<div class="container">
+    <table class="table table-striped table-hover">
+        <tbody>
+            <tr>
+                <th scope="row">Application bitness</th>
+                <td>@(Environment.Is64BitProcess ? "64-bit" : "32-bit")</td>
+            </tr>
+            <tr>
+                <th scope="row">Profiler attached</th>
+                <td>@Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</td>
+            </tr>
+            <tr>
+                <th scope="row">Datadog.Trace.dll path</th>
+                <td>@typeof(Datadog.Trace.Tracer).Assembly.Location</td>
+            </tr>
+            <tr>
+                <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll</th>
+                <td>@typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly.Location</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="container">
+    <div>Environment Variables:</div>
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (Model.Any())
+            {
+                foreach (var envVar in Model)
+                {
+                    <tr>
+                        <th scope="row">@envVar.Key</th>
+                        <td>@envVar.Value</td>
+                    </tr>
+                }
+            }
+            else
+            {
+                <tr>
+                    <td colspan="2">(empty)</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/samples/Samples.AspNetMvc5/Views/_Layout.cshtml
+++ b/samples/Samples.AspNetMvc5/Views/_Layout.cshtml
@@ -11,11 +11,5 @@
     <div>
         @RenderBody()
     </div>
-
-    <footer>
-        <div>Samples.AspNetMvc5</div>
-        <div>Bitness: @(Environment.Is64BitProcess ? "64-bit" : "32-bit")</div>
-        <div>Profiler attached: @Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</div>
-    </footer>
 </body>
 </html>


### PR DESCRIPTION
Add additional details to `/home/index` view, useful for troubleshooting (e.g. environment variables, DLL paths).

![image](https://user-images.githubusercontent.com/1851278/45770431-5e285400-bc10-11e8-8b46-01738976da4b.png)
