### PR TITLE
allow more time for slow CI in another time-sensitive test

### DIFF
--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             span.Finish();
 
             double durationDifference = Math.Abs((((OpenTracingSpan)span).Duration - expectedDuration).TotalMilliseconds);
-            Assert.True(durationDifference < 20);
+            Assert.True(durationDifference < 100);
         }
 
         /*


### PR DESCRIPTION
"sometimes, 20 milliseconds is not enough"