### PR TITLE
msi installer: don't reboot

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -39,10 +39,6 @@
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.User"/>
     </Feature>
-
-    <InstallExecuteSequence>
-      <ScheduleReboot After='InstallFinalize'/>
-    </InstallExecuteSequence>
   </Product>
 
   <Fragment>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -123,6 +123,9 @@
                      Key="System\CurrentControlSet\Services\WAS">
           <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]DD_PROFILER_PROCESSES=w3wp.exe" Action="append"/>
         </RegistryKey>
+        <!-- W3SVC depends on WAS, so stopping WAS stops both services, and starting W3SVC starts both -->
+        <ServiceControl Id="WAS.Stop" Name="WAS" Stop="both" Wait="yes"/>
+        <ServiceControl Id="W3SVC.Start" Name="W3SVC" Start="both" Wait="yes"/>
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -123,9 +123,6 @@
                      Key="System\CurrentControlSet\Services\WAS">
           <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]DD_PROFILER_PROCESSES=w3wp.exe" Action="append"/>
         </RegistryKey>
-        <!-- W3SVC depends on WAS, so stopping WAS stops both services, and starting W3SVC starts both -->
-        <ServiceControl Id="WAS.Stop" Name="WAS" Stop="both" Wait="yes"/>
-        <ServiceControl Id="W3SVC.Start" Name="W3SVC" Start="both" Wait="yes"/>
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
~We figured out that instead of rebooting the system to have IIS pick up new environment variables, we can restart two services: `WAS` and `W3SVC`.~

Don't schedule a system reboot. Let users reboot or restart IIS at their convenience. Will add the **option** (default false) to restart IIS in a separate PR.