### PR TITLE
[StackExchange.Redis] get only hostname and port from configuration string, ignore the rest

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Redis.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Redis.cs
@@ -14,10 +14,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         internal static Scope CreateScope(string host, string port, string rawCommand, bool finishOnClose = true)
         {
             var scope = Tracer.Instance.StartActive(OperationName, serviceName: ServiceName, finishOnClose: finishOnClose);
-            var command = rawCommand;
-            if (command.Contains(" "))
+            int separatorIndex = rawCommand.IndexOf(' ');
+            string command;
+
+            if (separatorIndex >= 0)
             {
-                command = command.Substring(0, command.IndexOf(' '));
+                command = rawCommand.Substring(0, separatorIndex);
+            }
+            else
+            {
+                command = rawCommand;
             }
 
             scope.Span.Type = SpanTypes.Redis;


### PR DESCRIPTION
Configuration string for `StackExchange.Redis` can contain several settings separated by commas:
```
hostname:port,name=MyName,keepAlive=180,syncTimeout=10000,abortConnect=False
```
Pick only the one with the hostname and port and ignore the rest.

Bonus: search for a space in command string once, not twice (`Contains()` and `IndexOf()`)

Before:
![image](https://user-images.githubusercontent.com/1851278/46050977-fb99f100-c104-11e8-9196-027b786bb6eb.png)
