### PR TITLE
use generics, test GET

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -148,7 +148,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.3.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchangeRedis",
           "method": "ExecuteSyncImpl",
-          "signature": "00 04 1C 1C 1C 1C 1C"
+          "signature": "10 01 04 1E 00 1C 1C 1C 1C"
         }
       },
       {
@@ -164,7 +164,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.3.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchangeRedis",
           "method": "ExecuteAsyncImpl",
-          "signature": "00 05 1C 1C 1C 1C 1C 1C"
+          "signature": "10 01 05 1E 00 1C 1C 1C 1C 1C"
         }
       }
     ]

--- a/integrations.json
+++ b/integrations.json
@@ -164,7 +164,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.3.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchangeRedis",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 05 1E 00 1C 1C 1C 1C 1C"
+          "signature": "10 01 05 1C 1C 1C 1C 1C 1C"
         }
       }
     ]

--- a/samples/Samples.RedisCore/Program.cs
+++ b/samples/Samples.RedisCore/Program.cs
@@ -80,6 +80,7 @@ namespace Samples.RedisCore
                     { "SLOWLOG", () => db.Execute("SLOWLOG", "GET") },
                     { "INCR", () => db.StringIncrement($"{prefix}INCR") },
                     { "INCR", () => db.StringIncrement($"{prefix}INCR", 1.25) },
+                    { "GET", () => db.StringGet($"{prefix}INCR") },
                     { "TIME", () => db.Execute("TIME") },
                 });
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchangeRedis.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchangeRedis.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -55,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <returns>An asynchronous task.</returns>
         public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server)
         {
-            var resultType = typeof(T);
+            var resultType = typeof(Task<T>);
             var asm = multiplexer.GetType().Assembly;
             var multiplexerType = asm.GetType("StackExchange.Redis.ConnectionMultiplexer");
             var messageType = asm.GetType("StackExchange.Redis.Message");
@@ -63,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var stateType = typeof(object);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, object, T>>.CreateMethodCallDelegate(
+            var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, object, Task<T>>>.CreateMethodCallDelegate(
                 multiplexerType,
                 "ExecuteAsyncImpl",
                 new Type[] { messageType, processorType, stateType, serverType },

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchangeRedis.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchangeRedis.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="state">The state to use for the task.</param>
         /// <param name="server">The server to call.</param>
         /// <returns>An asynchronous task.</returns>
-        public static T ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server)
+        public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server)
         {
             var resultType = typeof(T);
             var asm = multiplexer.GetType().Assembly;
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             using (var scope = CreateScope(multiplexer, message, server, finishOnClose: false))
             {
-                return (T)scope.Span.Trace(() => originalMethod(multiplexer, message, processor, state, server));
+                return scope.Span.Trace(() => originalMethod(multiplexer, message, processor, state, server));
             }
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -45,6 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     { "SLOWLOG", "SLOWLOG" },
                     { "INCR", $"INCR {prefix}StackExchange.Redis.INCR" },
                     { "INCRBYFLOAT", $"INCRBYFLOAT {prefix}StackExchange.Redis.INCR" },
+                    { "GET", $"GET {prefix}StackExchange.Redis.INCR" },
                     { "TIME", "TIME" },
                 };
 


### PR DESCRIPTION
`ExecuteSyncImpl` and `ExcuteAsyncImpl` sometimes returned a value type instead of an object type resulting in the method crashing. This should fix that issue by using a generic `<T>` instead.