### PR TITLE
[WIP] Make TraceID and SpanID publicly accessible

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -13,12 +13,12 @@ namespace Datadog.Trace
     /// </summary>
     public class Span : IDisposable
     {
-        private static ILog _log = LogProvider.For<Span>();
+        private static readonly ILog _log = LogProvider.For<Span>();
 
-        private object _lock = new object();
-        private IDatadogTracer _tracer;
-        private Dictionary<string, string> _tags;
-        private SpanContext _context;
+        private readonly object _lock = new object();
+        private readonly SpanContext _context;
+        private readonly IDatadogTracer _tracer;
+        private readonly Dictionary<string, string> _tags = new Dictionary<string, string>();
 
         internal Span(IDatadogTracer tracer, SpanContext parent, string operationName, string serviceName, DateTimeOffset? start)
         {
@@ -134,11 +134,6 @@ namespace Datadog.Trace
                 {
                     _log.Debug("SetTag should not be called after the span was closed");
                     return this;
-                }
-
-                if (_tags == null)
-                {
-                    _tags = new Dictionary<string, string>();
                 }
 
                 if (value == null)

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -61,6 +61,16 @@ namespace Datadog.Trace
         /// </summary>
         public string ServiceName => _context.ServiceName;
 
+        /// <summary>
+        /// Gets the trace's unique identifier.
+        /// </summary>
+        public ulong TraceId => _context.TraceId;
+
+        /// <summary>
+        /// Gets the span's unique identifier.
+        /// </summary>
+        public ulong SpanId => _context.SpanId;
+
         internal SpanContext Context => _context;
 
         internal ITraceContext TraceContext => _context.TraceContext;

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace
 
         // This is threadsafe only if used after the span has been closed.
         // It is acceptable because this property is internal. But if we were to make it public we would need to add some checks.
-        internal IReadOnlyDictionary<string, string> Tags => _tags;
+        internal ConcurrentDictionary<string, string> Tags => _tags;
 
         internal bool IsFinished { get; private set; }
 


### PR DESCRIPTION
A little refactoring in the `Span` class:
- add public `TraceId` and `SpanId` properties for #133 (the values are not secret and were already visible through `ToString()`)
- use `ConcurrentDictionary` instead of locks