### PR TITLE
[MVC 5] add missing tags when using attribute routing

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Web;
 using System.Web.Routing;
 using Datadog.Trace.ExtensionMethods;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -70,8 +70,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 span.SetTag(Tags.AspNetRoute, (string)controllerContext.RouteData.Route.Url);
                 span.SetTag(Tags.AspNetController, controllerName);
                 span.SetTag(Tags.AspNetAction, actionName);
-
-                _scope = Tracer.Instance.ActivateSpan(span, finishOnClose: true);
             }
             catch
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -16,23 +16,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         internal const string OperationName = "aspnet-mvc.request";
         private const string HttpContextKey = "__Datadog.Trace.ClrProfiler.Integrations.AspNetMvc5Integration";
 
-        private static readonly Type ControllerContextType;
+        private static readonly Type ControllerContextType = Type.GetType("System.Web.Mvc.ControllerContext, System.Web.Mvc", throwOnError: false);
+        private static readonly Type RouteCollectionRouteType = Type.GetType("System.Web.Mvc.Routing.RouteCollectionRoute, System.Web.Mvc", throwOnError: false);
 
         private readonly HttpContextBase _httpContext;
         private readonly Scope _scope;
-
-        static AspNetMvc5Integration()
-        {
-            try
-            {
-                Assembly assembly = Assembly.Load("System.Web.Mvc");
-                ControllerContextType = assembly.GetType("System.Web.Mvc.ControllerContext", throwOnError: false);
-            }
-            catch
-            {
-                ControllerContextType = null;
-            }
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AspNetMvc5Integration"/> class.

--- a/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Datadog.Trace.ExtensionMethods
 {
@@ -12,10 +10,8 @@ namespace Datadog.Trace.ExtensionMethods
             {
                 return value;
             }
-            else
-            {
-                return default(TValue);
-            }
+
+            return default(TValue);
         }
     }
 }


### PR DESCRIPTION
bugfix:
- add fallback to get action name and route template from alternate location when using attribute routing, e.g. `[Route("/path/{id}")]`

bonus clean up:
- remove unnecessary call to `ActivateSpan()` because the `Span` is already start in an active state with `StartActive()`.
- do not try to load assembly with `Assembly.Load()`