### PR TITLE
Add .NET Core support to msi installer

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <Include>
-  <?define BaseProductName = ".NET Tracing" ?>
+  <?define BaseProductName = ".NET Tracer" ?>
   <?define ArpManufacturer = "Datadog, Inc." ?>
   <?define Company = "Datadog" ?>
   <?define ManagedDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(var.Configuration)\net45" ?>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -105,7 +105,7 @@
     <ComponentGroup Id="EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
-        <Environment Id="DD_INTEGRATIONS" Name="DD_INTEGRATIONS" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]\integrations.json" Part="all" />
+        <Environment Id="DD_INTEGRATIONS" Name="DD_INTEGRATIONS" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]integrations.json" Part="all" />
       </Component>
     </ComponentGroup>
 

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -114,14 +114,14 @@
         <CreateFolder/>
         <RegistryKey Root="HKLM"
                      Key="System\CurrentControlSet\Services\W3SVC">
-          <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]DD_PROFILER_PROCESSES=w3wp.exe" Action="append"/>
+          <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]CORECLR_ENABLE_PROFILING=1[~]CORECLR_PROFILER=$(var.ProfilerCLSID)" Action="append"/>
         </RegistryKey>
       </Component>
 
       <Component Id="Registry.EnvironmentVariables.WAS" Guid="{6CF8AB88-240E-4A0A-B630-43119C064AD4}" Win64="$(var.Win64)">
         <RegistryKey Root="HKLM"
                      Key="System\CurrentControlSet\Services\WAS">
-          <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]DD_PROFILER_PROCESSES=w3wp.exe" Action="append"/>
+          <RegistryValue Type="multiString" Name="Environment" Value="COR_ENABLE_PROFILING=1[~]COR_PROFILER=$(var.ProfilerCLSID)[~]CORECLR_ENABLE_PROFILING=1[~]CORECLR_PROFILER=$(var.ProfilerCLSID)" Action="append"/>
         </RegistryKey>
       </Component>
     </ComponentGroup>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -5,6 +5,10 @@
     <Version>0.4.0-beta</Version>
     <RootNamespace>Datadog.Trace.ClrProfiler</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <Description>
+      Instrumentation code used by .NET Tracer for Datadog APM.
+      Requires separate native library that implements the CLR Profiling API.
+    </Description>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -1,5 +1,5 @@
-#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/null_sink.h>
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <filesystem>
 
 #include "logging.h"
@@ -14,21 +14,31 @@ std::shared_ptr<spdlog::logger> GetLogger() {
     std::unique_lock<std::mutex> lck(mtx);
 
     try {
-      auto programdata = GetEnvironmentValue(L"PROGRAMDATA");
-      if (programdata.empty()) {
-        programdata = L"C:\\ProgramData";
-      }
-      auto path = std::filesystem::path(programdata)
-                      .append("Datadog")
-                      .append("logs")
-                      .append("dotnet-profiler.log");
+      const auto logger_enabled =
+          GetEnvironmentValue(L"DD_DOTNET_TRACER_LOG_ENABLED");
 
-      if (!std::filesystem::exists(path.parent_path())) {
-        std::filesystem::create_directories(path.parent_path());
-      }
-      logger = spdlog::rotating_logger_mt("dotnet-profiler", path.string(),
-                                          1024 * 1024 * 5, 3);
+      if (logger_enabled == L"0") {
+        // disable logging, useful if the logger itself is crashing
+        logger = spdlog::create<spdlog::sinks::null_sink_st>("dotnet-profiler");
+      } else {
+        auto programdata = GetEnvironmentValue(L"PROGRAMDATA");
+        if (programdata.empty()) {
+          programdata = L"C:\\ProgramData";
+        }
 
+        DWORD process_id = GetCurrentProcessId();
+
+        auto path = std::filesystem::path(programdata)
+                        .append("Datadog .NET Tracer")
+                        .append("logs")
+                        .append("dotnet-profiler-" + std::to_string(process_id) + ".log");
+
+        if (!std::filesystem::exists(path.parent_path())) {
+          std::filesystem::create_directories(path.parent_path());
+        }
+        logger = spdlog::rotating_logger_mt("dotnet-profiler", path.string(),
+                                            1024 * 1024 * 5, 3);
+      }
     } catch (...) {
       logger = spdlog::create<spdlog::sinks::null_sink_st>("dotnet-profiler");
     }


### PR DESCRIPTION
- add environment variables required to enable profiler in .NET Core (`CORECLR_*`)
- don't restrict process name to `w3wp.exe` (.NET Core apps run as child processes, not in-process)

I also published NuGet package [Datadog.Trace.ClrProfiler.Managed](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) that should be added to .NET Core apps that use automatic instrumentation.