### PR TITLE
allow FlushAndCloseAsync to be called more than once

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -32,7 +32,11 @@ namespace Datadog.Trace.Agent
 
         public async Task FlushAndCloseAsync()
         {
-            _processExit.SetResult(true);
+            if (!_processExit.TrySetResult(true))
+            {
+                return;
+            }
+
             await Task.WhenAny(_flushTask, Task.Delay(TimeSpan.FromSeconds(20)));
             if (!_flushTask.IsCompleted)
             {

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,6 +36,14 @@ namespace Datadog.Trace.Tests
             _agentWriter.WriteTrace(trace);
             await Task.Delay(TimeSpan.FromSeconds(1.5));
             _api.Verify(x => x.SendTracesAsync(It.Is<List<List<Span>>>(y => y.Single().Equals(trace))), Times.Once);
+        }
+
+        [Fact]
+        public async Task FlushTwice()
+        {
+            var w = new AgentWriter(_api.Object);
+            await w.FlushAndCloseAsync();
+            await w.FlushAndCloseAsync();
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-csharp/issues/172.