### PR TITLE
implement retries for posting trace data to agent

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Timers;
 using Datadog.Trace.Logging;
 using MsgPack.Serialization;
 
@@ -57,16 +58,58 @@ namespace Datadog.Trace.Agent
 
         private async Task SendAsync<T>(T value, Uri endpoint)
         {
+            MsgPackContent<T> content;
             try
             {
-                var content = new MsgPackContent<T>(value, _serializationContext);
-                var response = await _client.PostAsync(endpoint, content);
-                response.EnsureSuccessStatusCode();
+                content = new MsgPackContent<T>(value, _serializationContext);
             }
             catch (Exception ex)
             {
-                _log.ErrorException("An error occured while sending traces to the agent at {Endpoint}", ex, endpoint);
+                _log.ErrorException("An error occured while sending serializing traces", ex);
+                return;
             }
+
+            // retry up to 5 times with exponential backoff
+            var retryLimit = 5;
+            var retryCount = 1;
+            var sleepDuration = 100; // in milliseconds
+
+            while (true)
+            {
+                try
+                {
+                    var response = await _client.PostAsync(endpoint, content);
+                    response.EnsureSuccessStatusCode();
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (retryCount >= retryLimit)
+                    {
+                        _log.ErrorException("An error occured while sending traces to the agent at {Endpoint}", ex, endpoint);
+                        return;
+                    }
+                }
+
+                await Sleep(sleepDuration);
+
+                retryCount++;
+                sleepDuration *= 2;
+            }
+        }
+
+        private Task<bool> Sleep(int milliseconds)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            var timer = new Timer();
+            timer.Elapsed += (obj, args) =>
+            {
+                tcs.TrySetResult(true);
+            };
+            timer.Interval = milliseconds;
+            timer.AutoReset = false;
+            timer.Start();
+            return tcs.Task;
         }
     }
 }

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Agent
             }
             catch (Exception ex)
             {
-                _log.ErrorException("An error occured while sending serializing traces", ex);
+                _log.ErrorException("An error occurred while serializing traces", ex);
                 return;
             }
 
@@ -86,30 +86,16 @@ namespace Datadog.Trace.Agent
                 {
                     if (retryCount >= retryLimit)
                     {
-                        _log.ErrorException("An error occured while sending traces to the agent at {Endpoint}", ex, endpoint);
+                        _log.ErrorException("An error occurred while sending traces to the agent at {Endpoint}", ex, endpoint);
                         return;
                     }
                 }
 
-                await Sleep(sleepDuration);
+                await Task.Delay(sleepDuration);
 
                 retryCount++;
                 sleepDuration *= 2;
             }
-        }
-
-        private Task<bool> Sleep(int milliseconds)
-        {
-            var tcs = new TaskCompletionSource<bool>();
-            var timer = new Timer();
-            timer.Elapsed += (obj, args) =>
-            {
-                tcs.TrySetResult(true);
-            };
-            timer.Interval = milliseconds;
-            timer.AutoReset = false;
-            timer.Start();
-            return tcs.Task;
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -68,9 +69,13 @@ namespace Datadog.Trace.Tests
             var handler = new SetResponseHandler(response);
             var api = new Api(new Uri("http://localhost:1234"), handler);
 
+            var sw = new Stopwatch();
+            sw.Start();
             await api.SendTracesAsync(new List<List<Span>> { new List<Span> { _tracer.StartSpan("Operation") } });
+            sw.Stop();
 
-            Assert.Equal(1, handler.RequestsCount);
+            Assert.Equal(5, handler.RequestsCount);
+            Assert.InRange(sw.ElapsedMilliseconds, 1500, 10000); // should be ~ 1600ms
 
             // TODO:bertrand check that it's properly logged
         }


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-csharp/issues/149

I suspect that sometimes the local agent isn't going to be available and that's what's leading to the errors. With this change we will retry posting the data 5 times with an exponential backoff delay between each try.