### PR TITLE
fix Web API 2 integration when built-in tracing is enabled

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -77,6 +77,11 @@
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
+        <File Id="net45_Sigil.dll"
+              Source="$(var.ManagedDllPath)\Sigil.dll"
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
+      </Component>
+      <Component Win64="$(var.Win64)">
         <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
               Source="$(var.ManagedDllPath)\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>

--- a/samples/Samples.AspNetMvc5/App_Start/WebApiConfig.cs
+++ b/samples/Samples.AspNetMvc5/App_Start/WebApiConfig.cs
@@ -1,6 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System;
+using System.Configuration;
 using System.Web.Http;
 
 namespace Samples.AspNetMvc5
@@ -9,13 +8,21 @@ namespace Samples.AspNetMvc5
     {
         public static void Register(HttpConfiguration config)
         {
+            string enableSystemDiagnosticsTracing = ConfigurationManager.AppSettings["EnableSystemDiagnosticsTracing"] ??
+                                                    Environment.GetEnvironmentVariable("EnableSystemDiagnosticsTracing");
+
+            if (string.Equals(enableSystemDiagnosticsTracing, "true", StringComparison.InvariantCultureIgnoreCase))
+            {
+                config.EnableSystemDiagnosticsTracing();
+            }
+
             config.MapHttpAttributeRoutes();
 
             config.Routes.MapHttpRoute(
-                name: "DefaultApi",
-                routeTemplate: "api/{controller}/{id}",
-                defaults: new { id = RouteParameter.Optional }
-            );
+                                       name: "DefaultApi",
+                                       routeTemplate: "api/{controller}/{id}",
+                                       defaults: new { id = RouteParameter.Optional }
+                                      );
         }
     }
 }

--- a/samples/Samples.AspNetMvc5/Controllers/ApiController.cs
+++ b/samples/Samples.AspNetMvc5/Controllers/ApiController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web.Http;
 
 namespace Samples.AspNetMvc5.Controllers
@@ -11,14 +12,22 @@ namespace Samples.AspNetMvc5.Controllers
         public IHttpActionResult Delay(int seconds)
         {
             Thread.Sleep(TimeSpan.FromSeconds(seconds));
-            return Ok(seconds);
+            return Json(seconds);
+        }
+
+        [HttpGet]
+        [Route("api/delay-async/{seconds}")]
+        public async Task<IHttpActionResult> DelayAsync(int seconds)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(seconds)).ConfigureAwait(false);
+            return Json(seconds);
         }
 
         [HttpGet]
         [Route("api/environment")]
         public IHttpActionResult Environment()
         {
-            return Ok(System.Environment.GetEnvironmentVariables());
+            return Json(System.Environment.GetEnvironmentVariables());
         }
     }
 }

--- a/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/samples/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -52,6 +52,9 @@
     <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
+    <Reference Include="System.Web.Http.Tracing, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Tracing.5.2.3\lib\net45\System.Web.Http.Tracing.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>

--- a/samples/Samples.AspNetMvc5/packages.config
+++ b/samples/Samples.AspNetMvc5/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net45" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -19,8 +19,8 @@
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  <ItemGroup>
+    <PackageReference Include="Sigil" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using Sigil;
 
 namespace Datadog.Trace.ClrProfiler
 {
@@ -12,9 +13,9 @@ namespace Datadog.Trace.ClrProfiler
     /// </summary>
     /// <typeparam name="TDelegate">The type of delegate</typeparam>
     public static class DynamicMethodBuilder<TDelegate>
-            where TDelegate : Delegate
+        where TDelegate : Delegate
     {
-        private static ConcurrentDictionary<Key, TDelegate> _cached = new ConcurrentDictionary<Key, TDelegate>(new KeyComparer());
+        private static readonly ConcurrentDictionary<Key, TDelegate> _cached = new ConcurrentDictionary<Key, TDelegate>(new KeyComparer());
 
         /// <summary>
         /// Memoizes CreateMethodCallDelegate
@@ -31,21 +32,22 @@ namespace Datadog.Trace.ClrProfiler
             Type[] methodGenericArguments = null)
         {
             return _cached.GetOrAdd(
-                new Key(type, methodName, methodParameterTypes, methodGenericArguments),
-                key =>
-                {
-                    return CreateMethodCallDelegate(key.Type, key.MethodName, key.MethodParameterTypes, key.MethodGenericArguments);
-                });
+                                    new Key(type, methodName, methodParameterTypes, methodGenericArguments),
+                                    key => CreateMethodCallDelegate(
+                                                                    key.Type,
+                                                                    key.MethodName,
+                                                                    key.MethodParameterTypes,
+                                                                    key.MethodGenericArguments));
         }
 
         /// <summary>
         /// Creates a simple <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/> that
-        /// calls a method with the specified name and and parameter types.
+        /// calls a method with the specified name and parameter types.
         /// </summary>
-        /// <param name="type">The <see cref="Type"/> that contains the method.</param>
-        /// <param name="methodName">The name of the method.</param>
-        /// <param name="methodParameterTypes">optional types for the method parameters</param>
-        /// <param name="methodGenericArguments">optional generic type arguments for a generic method</param>
+        /// <param name="type">The <see cref="Type"/> that contains the method to call when the returned delegate is executed..</param>
+        /// <param name="methodName">The name of the method to call when the returned delegate is executed.</param>
+        /// <param name="methodParameterTypes">If not null, use method overload that matches the specified parameters.</param>
+        /// <param name="methodGenericArguments">If not null, use method overload that has the same number of generic arguments.</param>
         /// <returns>A <see cref="Delegate"/> that can be used to execute the dynamic method.</returns>
         public static TDelegate CreateMethodCallDelegate(
             Type type,
@@ -76,38 +78,42 @@ namespace Datadog.Trace.ClrProfiler
             }
 
             // find any method that matches by name and parameter types
-            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
-            methods = methods.Where(m => m.Name == methodName).ToArray();
+            IEnumerable<MethodInfo> methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                                                  .Where(m => m.Name == methodName);
+
+            // if methodParameterTypes was specified, check for a method that matches
             if (methodParameterTypes != null)
             {
                 methods = methods.Where(m =>
-                {
-                    var ps = m.GetParameters();
-                    if (ps.Length != methodParameterTypes.Length)
-                    {
-                        return false;
-                    }
+                                        {
+                                            var ps = m.GetParameters();
+                                            if (ps.Length != methodParameterTypes.Length)
+                                            {
+                                                return false;
+                                            }
 
-                    for (var i = 0; i < ps.Length; i++)
-                    {
-                        var t1 = ps[i].ParameterType;
-                        var t2 = methodParameterTypes[i];
+                                            for (var i = 0; i < ps.Length; i++)
+                                            {
+                                                var t1 = ps[i].ParameterType;
+                                                var t2 = methodParameterTypes[i];
 
-                        // generics can be tricky to compare for type equality
-                        // so we will just check the namespace and name
-                        if (t1.Namespace != t2.Namespace || t1.Name != t2.Name)
-                        {
-                            return false;
-                        }
-                    }
+                                                // generics can be tricky to compare for type equality
+                                                // so we will just check the namespace and name
+                                                if (t1.Namespace != t2.Namespace || t1.Name != t2.Name)
+                                                {
+                                                    return false;
+                                                }
+                                            }
 
-                    return true;
-                }).ToArray();
+                                            return true;
+                                        });
             }
 
             if (methodGenericArguments != null)
             {
-                methods = methods.Where(m => m.IsGenericMethodDefinition).ToArray();
+                methods = methods.Where(m => m.IsGenericMethodDefinition &&
+                                             m.GetGenericArguments().Length == methodGenericArguments.Length)
+                                 .ToArray();
             }
 
             MethodInfo methodInfo = methods.FirstOrDefault();
@@ -123,41 +129,53 @@ namespace Datadog.Trace.ClrProfiler
                 methodInfo = methodInfo.MakeGenericMethod(methodGenericArguments);
             }
 
-            var dynamicMethod = new DynamicMethod(methodName, returnType, parameterTypes, type);
-            ILGenerator ilGenerator = dynamicMethod.GetILGenerator();
+            Type[] effectiveParameterTypes;
 
-            for (int argumentIndex = 0; argumentIndex < parameterTypes.Length; argumentIndex++)
+            IEnumerable<Type> reflectedParameterTypes = methodInfo.GetParameters()
+                                                                  .Select(p => p.ParameterType);
+            if (methodInfo.IsStatic)
             {
-                if (argumentIndex == 0)
+                effectiveParameterTypes = reflectedParameterTypes.ToArray();
+            }
+            else
+            {
+                // for instance methods, insert object's type as first element in array
+                effectiveParameterTypes = new[] { type }
+                                         .Concat(reflectedParameterTypes)
+                                         .ToArray();
+            }
+
+            Emit<TDelegate> dynamicMethod = Emit<TDelegate>.NewDynamicMethod(methodInfo.Name);
+
+            // load each argument and cast or unbox as necessary
+            for (ushort argumentIndex = 0; argumentIndex < parameterTypes.Length; argumentIndex++)
+            {
+                Type delegateParameterType = parameterTypes[argumentIndex];
+                Type underlyingParameterType = effectiveParameterTypes[argumentIndex];
+
+                dynamicMethod.LoadArgument(argumentIndex);
+
+                if (underlyingParameterType.IsValueType && delegateParameterType == typeof(object))
                 {
-                    ilGenerator.Emit(OpCodes.Ldarg_0);
+                    dynamicMethod.UnboxAny(underlyingParameterType);
                 }
-                else if (argumentIndex == 1)
+                else if (underlyingParameterType != delegateParameterType)
                 {
-                    ilGenerator.Emit(OpCodes.Ldarg_1);
-                }
-                else if (argumentIndex == 2)
-                {
-                    ilGenerator.Emit(OpCodes.Ldarg_2);
-                }
-                else if (argumentIndex == 3)
-                {
-                    ilGenerator.Emit(OpCodes.Ldarg_3);
-                }
-                else if (argumentIndex < 256)
-                {
-                    ilGenerator.Emit(OpCodes.Ldarg_S, (byte)argumentIndex);
-                }
-                else
-                {
-                    ilGenerator.Emit(OpCodes.Ldarg, argumentIndex);
+                    dynamicMethod.CastClass(underlyingParameterType);
                 }
             }
 
-            ilGenerator.Emit(methodInfo.IsVirtual ? OpCodes.Callvirt : OpCodes.Call, methodInfo);
-            ilGenerator.Emit(OpCodes.Ret);
+            if (methodInfo.IsVirtual)
+            {
+                dynamicMethod.CallVirtual(methodInfo);
+            }
+            else
+            {
+                dynamicMethod.Call(methodInfo);
+            }
 
-            return (TDelegate)dynamicMethod.CreateDelegate(delegateType);
+            dynamicMethod.Return();
+            return dynamicMethod.CreateDelegate();
         }
 
         private struct Key

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -1,5 +1,10 @@
+#if NET45
+
+using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
@@ -11,6 +16,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         internal const string OperationName = "aspnet-web-api.request";
 
+        private static readonly Type HttpControllerContextType = Type.GetType("System.Web.Http.Controllers.HttpControllerContext, System.Web.Http", throwOnError: false);
+
         /// <summary>
         /// ExecuteAsync calls the underlying ExecuteAsync and traces the request.
         /// </summary>
@@ -18,23 +25,38 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="controllerContext">The controller context for the call</param>
         /// <param name="cancellationTokenSource">The cancellation token source</param>
         /// <returns>A task with the result</returns>
-        public static dynamic ExecuteAsync(dynamic @this, dynamic controllerContext, dynamic cancellationTokenSource)
+        public static object ExecuteAsync(object @this, object controllerContext, object cancellationTokenSource)
         {
             using (Scope scope = CreateScope(controllerContext))
             {
                 return scope.Span.Trace(
-                    () => @this.ExecuteAsync(controllerContext, ((CancellationTokenSource)cancellationTokenSource).Token),
-                    onComplete: e =>
-                    {
-                        if (e != null)
-                        {
-                            scope.Span.SetException(e);
-                        }
+                                        () =>
+                                        {
+                                            Type controllerType = @this.GetType();
+                                            Type[] parameterTypes = null; // { HttpControllerContextType, typeof(CancellationToken) };
 
-                        // some fields aren't set till after execution, so repopulate anything missing
-                        UpdateSpan(controllerContext, scope.Span);
-                        scope.Span.Finish();
-                    });
+                                            // in some cases, ExecuteAsync() is an explicit interface implementation,
+                                            // which is not public and has a different name, so try both
+                                            var executeAsyncFunc =
+                                                DynamicMethodBuilder<Func<object, object, CancellationToken, object>>
+                                                   .GetOrCreateMethodCallDelegate(controllerType, "ExecuteAsync", parameterTypes) ??
+                                                DynamicMethodBuilder<Func<object, object, CancellationToken, object>>
+                                                   .GetOrCreateMethodCallDelegate(controllerType, "System.Web.Http.Controllers.IHttpController.ExecuteAsync", parameterTypes);
+
+                                            CancellationToken cancellationToken = ((CancellationTokenSource)cancellationTokenSource).Token;
+                                            return executeAsyncFunc(@this, controllerContext, cancellationToken);
+                                        },
+                                        onComplete: e =>
+                                        {
+                                            if (e != null)
+                                            {
+                                                scope.Span.SetException(e);
+                                            }
+
+                                            // some fields aren't set till after execution, so repopulate anything missing
+                                            UpdateSpan(controllerContext, scope.Span);
+                                            scope.Span.Finish();
+                                        });
             }
         }
 
@@ -92,3 +114,5 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         }
     }
 }
+
+#endif

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -52,11 +52,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <returns>An asynchronous task.</returns>
         public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server)
         {
-            var resultType = typeof(Task<T>);
+            var genericType = typeof(T);
             var asm = multiplexer.GetType().Assembly;
             var multiplexerType = asm.GetType("StackExchange.Redis.ConnectionMultiplexer");
             var messageType = asm.GetType("StackExchange.Redis.Message");
-            var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(resultType);
+            var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(genericType);
             var stateType = typeof(object);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 multiplexerType,
                 "ExecuteAsyncImpl",
                 new Type[] { messageType, processorType, stateType, serverType },
-                new Type[] { resultType });
+                new Type[] { genericType });
 
             using (var scope = CreateScope(multiplexer, message, server, finishOnClose: false))
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -22,18 +22,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <returns>An asynchronous task.</returns>
         public static object ExecuteAsync<T>(object obj, object message, object processor, object server)
         {
-            var resultType = typeof(Task<T>);
+            var genericType = typeof(T);
             var asm = obj.GetType().Assembly;
             var batchType = asm.GetType("StackExchange.Redis.RedisBatch");
             var messageType = asm.GetType("StackExchange.Redis.Message");
-            var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(typeof(T));
+            var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(genericType);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
             var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, Task<T>>>.CreateMethodCallDelegate(
                 obj.GetType(),
                 "ExecuteAsync",
                 new Type[] { messageType, processorType, serverType },
-                new Type[] { resultType });
+                new Type[] { genericType });
 
             // we only trace RedisBatch methods here
             if (obj.GetType() == batchType)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -36,13 +36,13 @@ WSTRING Trim(const WSTRING &str) {
   WSTRING trimmed = str;
 
   auto lpos = trimmed.find_first_not_of(" \t"_W);
-  if (lpos != WSTRING::npos) {
+  if (lpos != WSTRING::npos && lpos > 0) {
     trimmed = trimmed.substr(lpos);
   }
 
-  auto rpos = trimmed.find_last_of(" \t"_W);
+  auto rpos = trimmed.find_last_not_of(" \t"_W);
   if (rpos != WSTRING::npos) {
-    trimmed = trimmed.substr(0, rpos);
+    trimmed = trimmed.substr(0, rpos + 1);
   }
 
   return trimmed;


### PR DESCRIPTION
The original goal of this PR was:
- fix Web API 2 integration breaking app when app uses `EnableSystemDiagnosticsTracing()` by emitting IL instead of using `dynamic`

To (hopefully) make our lives easier while emitting IL, I also made this change:
- use [`Sigil`](https://github.com/kevin-montrose/Sigil) to emit IL with validation and helpful error messages

While debugging, I also found other bugs:
- fix bug in C++ `Trim()` what would truncate strings with spaces
- use `RedisBase.ExecuteAsync()` should return `Task<T>`, not `Task<Task<T>>` (caught by Sigil!)
