### PR TITLE
linux improvements

### DIFF
--- a/docker/dotnet.dockerfile
+++ b/docker/dotnet.dockerfile
@@ -1,6 +1,6 @@
-FROM microsoft/dotnet:2.1-sdk
+FROM microsoft/dotnet:2.1-sdk-alpine
+
+RUN apk add bash libc6-compat
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it
-
-RUN apt-get update && apt-get install -y colortail

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -2,9 +2,10 @@
 set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-VERSION=0.4.0
+VERSION=0.4.1
 
 mkdir -p $DIR/../deploy/linux
+cp $DIR/../integrations.json $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64/
 
 cd $DIR/../deploy/linux
 for pkgtype in deb rpm tar ; do
@@ -14,9 +15,10 @@ for pkgtype in deb rpm tar ; do
         -t $pkgtype \
         -n datadog-dotnet-apm \
         -v $VERSION \
-        --prefix /opt/datadog \
+        $(if [ $pkgtype != 'tar' ] ; then echo --prefix /opt/datadog ; fi) \
         --chdir $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64 \
-        Datadog.Trace.ClrProfiler.Native.so
+        Datadog.Trace.ClrProfiler.Native.so \
+        integrations.json
 done
 
 gzip -f datadog-dotnet-apm.tar

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -34,6 +34,8 @@ target_include_directories("Datadog.Trace.ClrProfiler.Native.static"
 )
 target_link_libraries("Datadog.Trace.ClrProfiler.Native.static"
     /opt/re2/obj/libre2.a
+    -static-libgcc
+    -static-libstdc++
 )
 
 add_library("Datadog.Trace.ClrProfiler.Native" SHARED


### PR DESCRIPTION
* update version number
* add `integrations.json` to the deploy
* don't prefix the tarball with `/opt/datadog` 
* confirm that the `.so` works with alpine linux (which uses musl libc). Users will have to install `libc6-compat` but once that's done it works