### PR TITLE
keep linux (lf) line endings in bash scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 ###############################################################################
 * text=auto
 
+# Set line endings to LF, even on Windows. Otherwise, execution within Docker fails.
+# See https://help.github.com/articles/dealing-with-line-endings/
+*.sh text eol=lf
+*.bash text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #


### PR DESCRIPTION
... so we can run them using Docker for Windows