### PR TITLE
Elasticsearch fix method return type

### DIFF
--- a/samples/Samples.Elasticsearch/Properties/launchSettings.json
+++ b/samples/Samples.Elasticsearch/Properties/launchSettings.json
@@ -2,6 +2,17 @@
   "profiles": {
     "Samples.Elasticsearch": {
       "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "%UserProfile%\\source\\repos\\dd-trace-csharp\\src\\Datadog.Trace.ClrProfiler.Native\\bin\\Debug\\x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "%UserProfile%\\source\\repos\\dd-trace-csharp\\src\\Datadog.Trace.ClrProfiler.Native\\bin\\Debug\\x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_INTEGRATIONS": "%UserProfile%\\source\\repos\\dd-trace-csharp\\integrations.json"
+      },
       "nativeDebugging": true
     }
   }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Elasticsearch.Net/Pipeline.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Elasticsearch.Net/Pipeline.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.Elasticsearch.Net
 {
@@ -59,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Elasticsearch.Net
 
             var cancellationToken = (cancellationTokenSource as CancellationTokenSource)?.Token ?? CancellationToken.None;
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, CancellationToken, TResponse>>.
+            var originalMethod = DynamicMethodBuilder<Func<object, object, CancellationToken, Task<TResponse>>>.
                 GetOrCreateMethodCallDelegate(
                     pipeline.GetType(),
                     "CallElasticsearchAsync",

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Elasticsearch.Net/Pipeline.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Elasticsearch.Net/Pipeline.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Elasticsearch.Net
             string method = null;
             try
             {
-                method = requestData?.Method;
+                method = requestData?.Method?.ToString();
             }
             catch
             {

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -46,6 +46,7 @@ namespace Datadog.Trace
                 if (_openSpans == 0)
                 {
                     _tracer.Write(_spans);
+                    _spans = new List<Span>();
                 }
             }
         }


### PR DESCRIPTION
Core tracer:
- replace span list with a new one after it's written in case more spans are added later

Elasticsearch integration
- fix return type of `CallElasticsearchAsync()` (caught by Sigil)
- convert http method enum to string