### PR TITLE
add support for `DD_AGENT_HOST` environment variable

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -17,9 +17,7 @@ namespace Datadog.Trace
         private const string UnknownServiceName = "UnknownService";
         private const string DefaultTraceAgentHost = "localhost";
         private const string DefaultTraceAgentPort = "8126";
-
-        private static readonly ILog Log = LogProvider.For<Tracer>();
-        private static readonly Uri DefaultAgentUri;
+        private const string TraceAgentPortEnvironmentVariableName = "DD_TRACE_AGENT_PORT";
 
         private static readonly string[] TraceAgentHostEnvironmentVariableNames =
         {
@@ -30,7 +28,8 @@ namespace Datadog.Trace
             "DD_TRACE_AGENT_HOSTNAME"
         };
 
-        private static readonly string TraceAgentPortEnvironmentVariableName = "DD_TRACE_AGENT_PORT";
+        private static readonly ILog Log = LogProvider.For<Tracer>();
+        private static readonly Uri DefaultAgentUri;
 
         private readonly AsyncLocalScopeManager _scopeManager;
         private readonly IAgentWriter _agentWriter;

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace
         private const string DefaultTraceAgentPort = "8126";
 
         private static readonly ILog Log = LogProvider.For<Tracer>();
+        private static readonly Uri DefaultAgentUri;
 
         private static readonly string[] TraceAgentHostEnvironmentVariableNames =
         {
@@ -37,6 +38,7 @@ namespace Datadog.Trace
 
         static Tracer()
         {
+            DefaultAgentUri = GetAgentUri();
             Instance = Create();
         }
 
@@ -88,11 +90,11 @@ namespace Datadog.Trace
         /// <returns>The newly created tracer</returns>
         public static Tracer Create(Uri agentEndpoint = null, string defaultServiceName = null, bool isDebugEnabled = false)
         {
-            return Create(agentEndpoint ?? GetAgentUri(), defaultServiceName, null, isDebugEnabled);
+            return Create(agentEndpoint ?? DefaultAgentUri, defaultServiceName, null, isDebugEnabled);
         }
 
         /// <summary>
-        /// Make a span active and return a scope that can be disposed to desactivate the span
+        /// Make a span active and return a scope that can be disposed to close the span
         /// </summary>
         /// <param name="span">The span to activate</param>
         /// <param name="finishOnClose">If set to false, closing the returned scope will not close the enclosed span </param>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -17,15 +17,22 @@ namespace Datadog.Trace
         private const string UnknownServiceName = "UnknownService";
         private const string DefaultTraceAgentHost = "localhost";
         private const string DefaultTraceAgentPort = "8126";
-        private const string TraceAgentPortEnvironmentVariableName = "DD_TRACE_AGENT_PORT";
 
         private static readonly string[] TraceAgentHostEnvironmentVariableNames =
         {
             // officially documented name
             "DD_AGENT_HOST",
-
             // backwards compatibility for names used in the past
-            "DD_TRACE_AGENT_HOSTNAME"
+            "DD_TRACE_AGENT_HOSTNAME",
+            "DATADOG_TRACE_AGENT_HOSTNAME"
+        };
+
+        private static readonly string[] TraceAgentPortEnvironmentVariableNames =
+        {
+            // officially documented name
+            "DD_TRACE_AGENT_PORT",
+            // backwards compatibility for names used in the past
+            "DATADOG_TRACE_AGENT_PORT"
         };
 
         private static readonly ILog Log = LogProvider.For<Tracer>();
@@ -169,11 +176,13 @@ namespace Datadog.Trace
         {
             var host = TraceAgentHostEnvironmentVariableNames.Select(Environment.GetEnvironmentVariable)
                                                              .FirstOrDefault(str => !string.IsNullOrEmpty(str))
-                                                            ?.Trim();
+                                                            ?.Trim() ?? DefaultTraceAgentHost;
 
-            var port = Environment.GetEnvironmentVariable(TraceAgentPortEnvironmentVariableName)?.Trim();
+            var port = TraceAgentPortEnvironmentVariableNames.Select(Environment.GetEnvironmentVariable)
+                                                             .FirstOrDefault(str => !string.IsNullOrEmpty(str))
+                                                            ?.Trim() ?? DefaultTraceAgentPort;
 
-            return new Uri($"http://{host ?? DefaultTraceAgentHost}:{port ?? DefaultTraceAgentPort}");
+            return new Uri($"http://{host}:{port}");
         }
 
         private static string CreateDefaultServiceName()

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -37,7 +37,10 @@ namespace Datadog.Trace
 
         static Tracer()
         {
-            DefaultAgentUri = GetAgentUri();
+            // create Agent uri once and save it
+            DefaultAgentUri = CreateAgentUri();
+
+            // create the default global Tracer
             Instance = Create();
         }
 
@@ -157,7 +160,12 @@ namespace Datadog.Trace
             return tracer;
         }
 
-        internal static Uri GetAgentUri()
+        /// <summary>
+        /// Create an Uri to the Agent using host and port from
+        /// environment variables or defaults if not set.
+        /// </summary>
+        /// <returns>An Uri that can be used to send traces to the Agent.</returns>
+        internal static Uri CreateAgentUri()
         {
             var host = TraceAgentHostEnvironmentVariableNames.Select(Environment.GetEnvironmentVariable)
                                                              .FirstOrDefault(str => !string.IsNullOrEmpty(str))

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -157,7 +157,7 @@ namespace Datadog.Trace
             return tracer;
         }
 
-        private static Uri GetAgentUri()
+        internal static Uri GetAgentUri()
         {
             var host = TraceAgentHostEnvironmentVariableNames.Select(Environment.GetEnvironmentVariable)
                                                              .FirstOrDefault(str => !string.IsNullOrEmpty(str))

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -255,5 +255,20 @@ namespace Datadog.Trace.Tests
                 Assert.Equal(root.Span.Context.SpanId, span.Span.Context.ParentId);
             }
         }
+
+        [Theory]
+        [InlineData("ddagent1", "5001", "http://ddagent1:5001")]
+        [InlineData("ddagent2", "5002", "http://ddagent2:5002")]
+        [InlineData("", "", "http://localhost:8126")]
+        [InlineData(null, null, "http://localhost:8126")]
+        public void SetHostAndPortEnvironmentVariables(string host, string port, string expectedUri)
+        {
+            Environment.SetEnvironmentVariable("DD_AGENT_HOST", host);
+            Environment.SetEnvironmentVariable("DD_TRACE_AGENT_PORT", port);
+
+            Uri uri = Tracer.GetAgentUri();
+
+            Assert.Equal(new Uri(expectedUri), uri);
+        }
     }
 }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -268,7 +268,7 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable("DD_AGENT_HOST", host);
             Environment.SetEnvironmentVariable("DD_TRACE_AGENT_PORT", port);
 
-            Uri uri = Tracer.GetAgentUri();
+            Uri uri = Tracer.CreateAgentUri();
 
             Assert.Equal(new Uri(expectedUri), uri);
 

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -257,18 +257,24 @@ namespace Datadog.Trace.Tests
         }
 
         [Theory]
-        [InlineData("ddagent1", "5001", "http://ddagent1:5001")]
-        [InlineData("ddagent2", "5002", "http://ddagent2:5002")]
+        [InlineData("ddagent", "5000", "http://ddagent:5000")]
         [InlineData("", "", "http://localhost:8126")]
         [InlineData(null, null, "http://localhost:8126")]
         public void SetHostAndPortEnvironmentVariables(string host, string port, string expectedUri)
         {
+            string originalHost = Environment.GetEnvironmentVariable("DD_AGENT_HOST");
+            string originalPort = Environment.GetEnvironmentVariable("DD_TRACE_AGENT_PORT");
+
             Environment.SetEnvironmentVariable("DD_AGENT_HOST", host);
             Environment.SetEnvironmentVariable("DD_TRACE_AGENT_PORT", port);
 
             Uri uri = Tracer.GetAgentUri();
 
             Assert.Equal(new Uri(expectedUri), uri);
+
+            // reset the environment variables to their original values (if any) when done
+            Environment.SetEnvironmentVariable("DD_AGENT_HOST", originalHost);
+            Environment.SetEnvironmentVariable("DD_TRACE_AGENT_PORT", originalPort);
         }
     }
 }


### PR DESCRIPTION
- add support for `DD_AGENT_HOST` environment variable (while keeping a fallback for the old `DD_TRACE_AGENT_HOSTNAME`)

code clean-up:
- make fields `const` or `readonly` where possible
- rename fields to match conventions