### PR TITLE
readme file: replace CircleCI badge with Azure for Linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **NOTE: The .NET Tracer is currently in Public Beta.**
 
+## Installation and Usage
+
+Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for instructions on setting up .NET tracing and details about supported frameworks.
+
 ## Downloads
 Package|Download
 --|--
@@ -19,10 +23,6 @@ Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-tra
 Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=5)
 Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=2)
 Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=13)
-
-## Installation and Usage
-
-Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for instructions on setting up .NET tracing and details about supported frameworks.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 OS|Tests|Status
 --|--|--
-Windows|C# unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=1)
-Windows|C++ unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=11)
-Windows|integration tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=5)
-Linux|C# unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
-Linux|integration tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=13)
+Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=1)
+Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=11)
+Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=5)
+Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=2)
+Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=13)
 
 ## Installation and Usage
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Windows and Linux Installers|[Releases page](https://github.com/DataDog/dd-trace
 
 OS|Tests|Status
 --|--|--
-Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=1)
-Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=11)
-Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=5)
-Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=2)
-Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=13)
+Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=1)
+Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=11)
+Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=5)
+Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=2)
+Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=13)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Windows and Linux Installers|[Releases page](https://github.com/DataDog/dd-trace
 
 OS|Tests|Status
 --|--|--
-Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=1)
-Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=11)
-Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=5)
-Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=2)
-Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=13)
+Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=1)
+Windows|C++ unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=11)
+Windows|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=5)
+Linux|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=2)
+Linux|integration tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=13)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Windows|C# unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-t
 Windows|C++ unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-native)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=11)
 Windows|integration tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Windows/windows-integration-tests)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=5)
 Linux|C# unit tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux/linux-unit-tests-managed)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=2)
-Linux|integration tests|[![CircleCI](https://circleci.com/gh/DataDog/dd-trace-csharp/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-csharp/tree/master)
+Linux|integration tests|[![Build Status](https://datadog-apm.visualstudio.com/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests)](https://datadog-apm.visualstudio.com/dd-trace-csharp/_build/latest?definitionId=13)
 
 ## Installation and Usage
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 **NOTE: The .NET Tracer is currently in Public Beta.**
 
+## Downloads
+Package|Download
+--|--
+Windows and Linux Installers|[Releases page](https://github.com/DataDog/dd-trace-csharp/releases)
+`Datadog.Trace`|[![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)
+`Datadog.Trace.OpenTracing`|[![Datadog.Trace.OpenTracing](https://img.shields.io/nuget/vpre/Datadog.Trace.OpenTracing.svg)](https://www.nuget.org/packages/Datadog.Trace.OpenTracing)
+`Datadog.Trace.ClrProfiler.Managed`|[![Datadog.Trace.ClrProfiler.Managed](https://img.shields.io/nuget/vpre/Datadog.Trace.ClrProfiler.Managed.svg)](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed)
+
+## Build Status
+
 OS|Tests|Status
 --|--|--
 Windows|C# unit tests|[![Build Status](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Windows/windows-unit-tests-managed)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build/latest?definitionId=1)


### PR DESCRIPTION
1) replace CircleCI badge with Azure Pipelines (VSTS) for Linux builds in the `README.md` file

Old|New
-|-
[![CircleCI](https://circleci.com/gh/DataDog/dd-trace-csharp/tree/master.svg?style=svg)](https://circleci.com/gh/DataDog/dd-trace-csharp/tree/master)|[![Azure Pipelines](https://dev.azure.com/datadog-apm/dd-trace-csharp/_apis/build/status/Linux/linux-integration-tests?branchName=develop)](https://dev.azure.com/datadog-apm/dd-trace-csharp/_build?definitionId=13)

2) add new NuGet badges:
[![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)

3) fix URLs in existing Azure badges (from `datadog-apm.visualstudio.com` to `dev.azure.com/datadog-apm`)

[See preview here.](https://github.com/DataDog/dd-trace-csharp/blob/cd3b59af7d660504f7a0092931bdf15af2813108/README.md)