### PR TITLE
Fix whitespace in C++ logs

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -15,7 +15,7 @@ inline std::string LogToString(Arg const &arg) {
 template <typename... Args>
 inline std::string LogToString(Args const &... args) {
   std::ostringstream oss;
-  int a[] = {0, ((void)(oss << LogToString(args) << " "), 0)...};
+  int a[] = {0, ((void)(oss << LogToString(args)), 0)...};
   return oss.str();
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -24,7 +24,7 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
     assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
   }
 
-  Info("EmitAssemblyRef", assembly_ref.str());
+  Info("EmitAssemblyRef ", assembly_ref.str());
 
   DWORD public_key_size = 8;
   if (assembly_ref.public_key == trace::PublicKey()) {


### PR DESCRIPTION
Small PR to add missing spaces (and remove redundant ones) from logs generated in C++ profiler code.